### PR TITLE
Remove the eBenefits button from the eligibility page

### DIFF
--- a/pages/disability/eligibility.md
+++ b/pages/disability/eligibility.md
@@ -97,22 +97,6 @@ If you've received one of these discharge statuses, you may not be eligible for 
 
 <div itemscope itemtype="http://schema.org/Question">
 
-<h3 itemprop="name">How do I apply?</h3>
-<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
-<div itemprop="text">
-
-You can apply online right now.
-
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation">Go to eBenefits to Apply</a>
-
-[Learn more about how to apply for disability benefits](/disability/how-to-file-claim/).
-
-</div>
-</div>
-</div>
-
-<div itemscope itemtype="http://schema.org/Question">
-
 <h3 itemprop="name">What conditions are covered by these benefits?</h3>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">


### PR DESCRIPTION
Connected to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14661
(Looks like I can't connect it ZenHub at the moment.)

I think this is another victim of the `vagov-content` extraction, but...I'm not 100% sure. Either way, the button needs to be gone, so here we go. :man_shrugging: 

![image](https://user-images.githubusercontent.com/12970166/47591859-f60f1100-d925-11e8-8e89-b400cb723938.png)
