### PR TITLE
Fix facility locator link on housing assistance page

### DIFF
--- a/pages/housing-assistance/index.md
+++ b/pages/housing-assistance/index.md
@@ -167,7 +167,7 @@ We offer many programs and services that may help—including free health care a
 
 - **Call the National Call Center for Homeless Veterans** at 1-877-4AID-VET (<a href="tel:+18774243838">1-877-424-3838</a>) for help 24 hours a day, 7 days a week. You’ll talk privately with a trained VA counselor for free.
 - **Contact your nearest VA medical center** and ask to talk with the VA social worker. If you're a female Veteran, ask for the Women Veterans Program Manager. <br>
-[Find the nearest VA medical center](#).
+[Find the nearest VA medical center](/facilities/?facilityType=health).
 
 **Talk with someone right now:**
 


### PR DESCRIPTION
This fixes the missing facility locator link in the alert on housing assistance.

Related: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14346