### PR TITLE
Remove extra div in how to apply page

### DIFF
--- a/pages/disability/va-claim-exam.md
+++ b/pages/disability/va-claim-exam.md
@@ -229,7 +229,6 @@ We may ask you to have a claim exam if you appeal your disability benefits decis
 </div>
 </li>
 </ul>
-</div>
 
 ### What if I have more questions about my exam?
 

--- a/pages/housing-assistance/home-loans/eligibility.md
+++ b/pages/housing-assistance/home-loans/eligibility.md
@@ -69,7 +69,6 @@ You may be able to get a COE if you didn't receive a dishonorable discharge and 
 </div>
 </li>
 </ul>
-</div>
 
 <br>
 

--- a/pages/housing-assistance/home-loans/how-to-apply.md
+++ b/pages/housing-assistance/home-loans/how-to-apply.md
@@ -131,7 +131,6 @@ If you’re a **surviving spouse** who qualifies for home loan benefits, you’l
 </div>
 </li>
 </ul>
-</div>
 
 <!-- </li>
 


### PR DESCRIPTION
There's an extra div in this page, which pushes the content down.

Related to: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14761

![screen shot 2018-10-31 at 5 25 26 pm](https://user-images.githubusercontent.com/634932/47819834-0c580b00-dd32-11e8-94f2-b280ae543489.png)
