### PR TITLE
Remove extraneous fields from search form

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -32,7 +32,7 @@ private: true
               <div class="va-flex va-flex--top va-flex--jctr">
                 <label for="mobile-query">Search:</label>
                 <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
-                <input name="commit" type="submit" value="Search">
+                <input type="submit" value="Search">
               </div>
             </form>
           </div>

--- a/pages/404.md
+++ b/pages/404.md
@@ -29,14 +29,10 @@ private: true
             {% else %}
               <form accept-charset="UTF-8" action="/search" id="search_form" class="full-width" method="get">
             {% endif %}
-              <div class="csp-inline-patch-404">
-                <input name="utf8" type="hidden" value="&#x2713;" />
-              </div>
               <div class="va-flex va-flex--top va-flex--jctr">
-                <input id="affiliate-1" name="affiliate-1" type="hidden" value="vets.gov_search" />
-                  <label for="mobile-query">Search:</label>
-                  <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
-                  <input name="commit" type="submit" value="Search">
+                <label for="mobile-query">Search:</label>
+                <input autocomplete="off" class="usagov-search-autocomplete full-width" id="mobile-query" name="query" type="text" />
+                <input name="commit" type="submit" value="Search">
               </div>
             </form>
           </div>


### PR DESCRIPTION
## Description
When using search.gov's hosted pages, we were passing &utf8=✓&affiliate=va into the URL as required by their docs. We can safely remove these now that we're using a vets-api based approach.

See issue [#14795](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14795)

See sibling pr in vets-website [here](https://github.com/department-of-veterans-affairs/vets-website/pull/8981)

## Testing done
Verified locally that when submitting a search the params are not including in the URL. 
Verified on [heroku build](https://vagov-content-pr-91.herokuapp.com/) that change is present.

## Acceptance criteria
- [x] When using the dropdown search or 404 page search, when executing a query, the URL does not include &utf= or &affiliate= query params.

