### PR TITLE
Hide pages from www.va.gov that are currently hidden from preview.va.gov

### DIFF
--- a/pages/connected-accounts/index.md
+++ b/pages/connected-accounts/index.md
@@ -4,6 +4,7 @@ layout: page-react.html
 entryname: connected-accounts
 preview: false
 vagovstaging: false
+vagovprod: false
 ---
 <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">

--- a/pages/disability-benefits/apply/form-526-all-claims.md
+++ b/pages/disability-benefits/apply/form-526-all-claims.md
@@ -6,6 +6,7 @@ description: Learn how to apply online for disability compensation.
 hideFromSidebar: true
 production: false
 preview: false
+vagovprod: false
 ---
 <div id="main">
   <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs"

--- a/pages/search.md
+++ b/pages/search.md
@@ -3,6 +3,4 @@ title: Search Results
 layout: page-react.html
 entryname: search
 includeBreadcrumbs: true
-production: true
-preview: true
 ---


### PR DESCRIPTION
This PR removes pages from the future www.va.gov that are hidden from preview.va.gov by adding `vagovprod: false` in the front matter.

Move to validate https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14822