### PR TITLE
Temporary fix:  logout redirect

### DIFF
--- a/pages/logout.md
+++ b/pages/logout.md
@@ -17,9 +17,7 @@ private: true
 </div>
 
 <script>
-if (location.search.substring(1) === 'success=true') {
   window.opener.sessionStorage.clear();
   window.opener.document.location.href = '/';
   window.close();
-}
 </script>


### PR DESCRIPTION
The popup isn't closing and localstorage isn't being cleared because we loose the parameter
success=true in a redirect, possibly from nginx.  This will put a bandaid on the typical user
experience