### PR TITLE
Content deploy fast

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ node('vetsgov-general-purpose') {
       // The build script will use this flag to pull the compiled app-code from the www.va.gov S3 bucket.
 
       def installDependencies = "cd /application && yarn install --production=false"
-      def build = "cd /application && npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
+      def build = "npm --prefix /application --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
       def preArchive = "cd /application && node script/pre-archive/index.js --buildtype=${productionEnv}"
 
       sh installDependencies

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ node('vetsgov-general-purpose') {
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=../${contentRepo}"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=/${contentRepo}"
         def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
         sh 'cd /application'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ node('vetsgov-general-purpose') {
     dir(appCodeRepo) {
       checkoutAppCode()
 
-      def tag = 'vets-website-v0-1-383' //getTagOfAppCodeLatestRelease()
+      def tag = 'vets-website/v0-1-383' //getTagOfAppCodeLatestRelease()
       sh "git checkout ${tag}"
 
       def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ node('vetsgov-general-purpose') {
 
       def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
       def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-      def dockerArgs = "-v ./:/application -v ../${contentRepo}:/${contentRepo}"
+      def dockerArgs = "-v .:/application -v ../${contentRepo}:/${contentRepo}"
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ node('vetsgov-general-purpose') {
         sh preArchive
 
         withCredentials(awsCredentials) {
-          def convertToTarball = "tar -C /application/build/${productionEnv} -cf /application/build/${productionEnv}.tar.bz2 ."
+          def convertToTarball = "tar -C /build/${productionEnv} -cf /build/${productionEnv}.tar.bz2 ."
           // def uploadTarball = "s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${ref}/${productionEnv}.tar.bz2"
 
           sh convertToTarball

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,11 +88,11 @@ node('vetsgov-general-purpose') {
       def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
       def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
       def currentDir = pwd()
-      def dockerArgs = "-v ${currentDir}:/application -v ../${contentRepo}:/${contentRepo}"
+      def dockerArgs = "-v ${currentDir}:/application -v ${currentDir}/../${contentRepo}:/${contentRepo}"
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=/${contentRepo}"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=../${contentRepo}"
         def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
         sh 'cd /application'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,8 @@ node('vetsgov-general-purpose') {
 
       def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
       def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-      def dockerArgs = "-v .:/application -v ../${contentRepo}:/${contentRepo}"
+      def currentDir = pwd()
+      def dockerArgs = "-v ${currentDir}:/application -v ../${contentRepo}:/${contentRepo}"
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,20 +90,17 @@ node('vetsgov-general-purpose') {
 
     dockerImage.inside(dockerArgs) {
 
-      dir('/application') {
-        def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
-        def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
+      def installDependencies = "cd /application && yarn install --production=false"
+      def build = "cd /application && npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
+      def preArchive = "cd /application && node script/pre-archive/index.js --buildtype=${productionEnv}"
 
-        sh installDependencies
-        sh build
-        sh preArchive
-
-      }
+      sh installDependencies
+      sh build
+      sh preArchive
 
       withCredentials(awsCredentials) {
         // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-        def convertToTarball = "tar -C build/${productionEnv} -cf build/${productionEnv}.tar.bz2 ."
+        def convertToTarball = "tar -C /application/build/${productionEnv} -cf /application/build/${productionEnv}.tar.bz2 ."
         // def uploadTarball = "\
         //   s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
         //   s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,11 +89,10 @@ node('vetsgov-general-purpose') {
     echo dockerArgs
 
     dockerImage.inside(dockerArgs) {
-      def installDependencies = "yarn install --production=false"
-      def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=/${contentRepo}"
-      def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
+      def installDependencies = "cd /application && yarn install --production=false"
+      def build = "cd /application && npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=/${contentRepo}"
+      def preArchive = "cd /application && node script/pre-archive/index.js --buildtype=${productionEnv}"
 
-      sh 'cd /application'
       sh installDependencies
       sh build
       sh preArchive

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,9 +93,9 @@ node('vetsgov-general-purpose') {
         withCredentials(awsCredentials) {
           // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
           def convertToTarball = "tar -C build/${productionEnv} -cf build/${productionEnv}.tar.bz2 ."
-          def uploadTarball = "\
-            s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
-            s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"
+          // def uploadTarball = "\
+          //   s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
+          //   s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"
 
           sh convertToTarball
           // echo uploadTarball

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,9 +97,7 @@ node('vetsgov-general-purpose') {
     def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
     def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
 
-    dir(appCodeRepo) {
-      sh "git checkout ${tag}"
-    }
+    sh "cd ${appCodeRepo} && git checkout ${tag}"
 
     dockerImage.inside(dockerArgs) {
       executeBuild(dockerImage)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ node('vetsgov-general-purpose') {
 
     dockerImage.inside(dockerArgs) {
       def installDependencies = "cd /application && yarn install --production=false"
-      def build = "cd /application && npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=/${contentRepo}"
+      def build = "cd /application && npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
       def preArchive = "cd /application && node script/pre-archive/index.js --buildtype=${productionEnv}"
 
       sh installDependencies

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,16 +92,16 @@ node('vetsgov-general-purpose') {
       checkoutAppCode()
     }
 
-    def tag = getTagOfAppCodeLatestRelease()
-    def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
-    def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-    def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
+    // def tag = getTagOfAppCodeLatestRelease()
+    // def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
+    // def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
+    // def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
 
-    sh "cd ${appCodeRepo} && git checkout ${tag}"
+    // sh "cd ${appCodeRepo} && git checkout ${tag}"
 
-    dockerImage.inside(dockerArgs) {
-      // executeBuild(dockerImage)
-      // archiveBuild()
-    }
+    // dockerImage.inside(dockerArgs) {
+    //   // executeBuild(dockerImage)
+    //   // archiveBuild()
+    // }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,16 +92,16 @@ node('vetsgov-general-purpose') {
       checkoutAppCode()
     }
 
-    def tag = getTagOfAppCodeLatestRelease()
-    // def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
-    // def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-    // def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
+    def tag = 'vets-website/v0.1.383' //getTagOfAppCodeLatestRelease()
+    def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
+    def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
+    def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
 
-    // sh "cd ${appCodeRepo} && git checkout ${tag}"
+    sh "cd ${appCodeRepo} && git checkout ${tag}"
 
-    // dockerImage.inside(dockerArgs) {
-    //   // executeBuild(dockerImage)
-    //   // archiveBuild()
-    // }
+    dockerImage.inside(dockerArgs) {
+      // executeBuild(dockerImage)
+      // archiveBuild()
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,28 +49,25 @@ node('vetsgov-general-purpose') {
     passwordVariable: 'AWS_SECRET_KEY'
   ]]
 
-  def releaseTag, releaseCommit, dockerImage, contentCommit
+  def releaseTag, releaseCommit, dockerImage
 
+  // Dev/Staging should contain the latest code, so we can just issue a rebuild
+  // to the vets-website pipeline and know that'll handle the rest.
   stage('Rebuild Dev/Staging') {
     if (!isMaster) return
-
-    // Dev/Staging should contain the latest code, so we can just issue a rebuild
-    // to the vets-website pipeline and know that'll handle the rest.
 
     // build job: 'testing/vets-website/master', wait: false
   }
 
+  // Production is a special case, because it's not redeployed every commit, but
+  // every release instead. So, we need to rebuild Prod using the archive of the
+  // latest release.
   stage('Rebuild Production') {
     if (!isMaster) return
 
-    // Production is a special case, because it's not redeployed every commit, but
-    // every release instead. So, we need to rebuild Prod using the archive of the
-    // latest release.
-
-    // Checkout the content and grab a reference to the current commmit.
+    // Checkout the content.
     dir(contentRepo) {
       checkout scm
-      contentCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
     }
 
     // Checkout the app-code, then reset it to the latest commit.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ node('vetsgov-general-purpose') {
     dir(appCodeRepo) {
       checkoutAppCode()
 
-      def tag = 'vets-website/v0-1-383' //getTagOfAppCodeLatestRelease()
+      def tag = 'vets-website/v0.1.383' //getTagOfAppCodeLatestRelease()
       sh "git checkout ${tag}"
 
       def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,10 +115,10 @@ node('vetsgov-general-purpose') {
         sh convertToTarball
         sh uploadTarball
 
-        // build job: jobName, parameters: [
-        //   booleanParam(name: 'notify_slack', value: true),
-        //   stringParam(name: 'ref', value: ref),
-        // ], wait: false
+        build job: productionBuildJob, parameters: [
+          booleanParam(name: 'notify_slack', value: true),
+          stringParam(name: 'ref', value: tarballName),
+        ], wait: false
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,20 +85,20 @@ node('vetsgov-general-purpose') {
     // every release instead. So, we need to rebuild Prod using the archive of the
     // latest release.
 
-    def imageTag = java.net.URLDecoder.decode(latestReleaseTag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
-    def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-    def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
-
-    latestReleaseTag = getTagOfAppCodeLatestRelease()
-
     dir(contentRepo) {
       checkout scm
     }
 
     dir(appCodeRepo) {
       checkoutAppCode()
-      sh "git checkout ${latestReleaseTag}"
     }
+
+    def tag = getTagOfAppCodeLatestRelease()
+    def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
+    def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
+    def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
+
+    sh "cd ${appCodeRepo} && git checkout ${tag}"
 
     dockerImage.inside(dockerArgs) {
       executeBuild(dockerImage)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,6 @@ node('vetsgov-general-purpose') {
     build job: productionBuildJob, parameters: [
       booleanParam(name: 'notify_slack', value: true),
       stringParam(name: 'ref', value: releaseCommit),
-    ], wait: false
+    ], wait: true
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node('vetsgov-general-purpose') {
     passwordVariable: 'AWS_SECRET_KEY'
   ]]
 
-  def releaseTag, releaseCommit, dockerImage, contentCommit, tarballName
+  def releaseTag, releaseCommit, dockerImage, contentCommit
 
   stage('Rebuild Dev/Staging') {
     if (!isMaster) return
@@ -113,12 +113,11 @@ node('vetsgov-general-purpose') {
 
         // Upload to S3 using the commit SHA from the app-code, suffixed by the content commit SHA
 
-        tarballName = "${releaseCommit}__content-${contentCommit}"
-
+        // def tarballName = "${releaseCommit}__content-${contentCommit}"
         def convertToTarball = "tar -C /application/build/${productionEnv} -cf /application/build/${productionEnv}.tar.bz2 ."
         def uploadTarball = "\
           s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
-          s3://vetsgov-website-builds-s3-upload/${tarballName}/${productionEnv}.tar.bz2"
+          s3://vetsgov-website-builds-s3-upload/${releaseCommit}/${productionEnv}.tar.bz2"
 
         sh convertToTarball
         sh uploadTarball
@@ -131,7 +130,7 @@ node('vetsgov-general-purpose') {
 
     build job: productionBuildJob, parameters: [
       booleanParam(name: 'notify_slack', value: true),
-      stringParam(name: 'ref', value: tarballName),
+      stringParam(name: 'ref', value: releaseCommit),
     ], wait: false
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,14 +91,14 @@ node('vetsgov-general-purpose') {
         sh preArchive
 
         withCredentials(awsCredentials) {
-          def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+          // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
           def convertToTarball = "tar -C build/${productionEnv} -cf build/${productionEnv}.tar.bz2 ."
           def uploadTarball = "\
             s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
             s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"
 
           sh convertToTarball
-          echo uploadTarball
+          // echo uploadTarball
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,10 +82,10 @@ node('vetsgov-general-purpose') {
       // sh "git checkout ${releaseTag}"
       // releaseCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
 
-      // def imageTag = java.net.URLDecoder.decode(releaseTag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
+      releaseTag = 'vets-website/v0.1.383'
+      def imageTag = java.net.URLDecoder.decode(releaseTag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
 
       // temporary
-      releaseTag = 'vets-website/v0.1.383'
       releaseCommit = 'dab158f1e0bd5776963c4fa459a55c8237445f86'
       dockerImage = docker.build("${appCodeRepo}:${imageTag}")
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node('vetsgov-general-purpose') {
     passwordVariable: 'AWS_SECRET_KEY'
   ]]
 
-  def releaseTag, releaseCommit, dockerImage
+  def releaseTag, releaseCommit, dockerImage, contentCommit
 
   stage('Rebuild Dev/Staging') {
     if (!isMaster) return
@@ -69,6 +69,7 @@ node('vetsgov-general-purpose') {
 
     dir(contentRepo) {
       checkout scm
+      contentCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
     }
 
     dir(appCodeRepo) {
@@ -100,7 +101,7 @@ node('vetsgov-general-purpose') {
         def convertToTarball = "tar -C /application/build/${productionEnv} -cf /application/build/${productionEnv}.tar.bz2 ."
         def uploadTarball = "\
           s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
-          s3://vetsgov-website-builds-s3-upload/${releaseCommit}/${productionEnv}.tar.bz2"
+          s3://vetsgov-website-builds-s3-upload/${releaseCommit}__content-${contentCommit}/${productionEnv}.tar.bz2"
 
         sh convertToTarball
         echo uploadTarball

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,10 +104,12 @@ node('vetsgov-general-purpose') {
 
       // Upload to S3 using the commit SHA of the release.
       withCredentials(awsCredentials) {
-        def convertToTarball = "tar -C /application/build/${productionEnv} -cf /application/build/${productionEnv}.tar.bz2 ."
-        def uploadTarball = "\
-          s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
-          s3://vetsgov-website-builds-s3-upload/${releaseCommit}/${productionEnv}.tar.bz2"
+        def buildOutput = "/application/build/${productionEnv}"
+        def tarballFileName = "/application/build/${productionEnv}.tar.bz2"
+        def tarballUploadDestination = "s3://vetsgov-website-builds-s3-upload/${releaseCommit}/${productionEnv}.tar.bz2"
+
+        def convertToTarball = "tar -C ${buildOutput} -cf ${tarballFileName} ."
+        def uploadTarball = "s3-cli put --acl-public --region us-gov-west-1 ${tarballFileName} ${tarballUploadDestination}"
 
         sh convertToTarball
         sh uploadTarball

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ node('vetsgov-general-purpose') {
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=/${contentRepo}"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=/${contentRepo} --brand-consolidation-enabled"
         def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
         sh 'cd /application'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,18 +90,19 @@ node('vetsgov-general-purpose') {
 
     dir(appCodeRepo) {
       checkoutAppCode()
-    }
 
-    def tag = 'vets-website-v0-1-383' //getTagOfAppCodeLatestRelease()
-    def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
-    def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-    def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
+      def tag = 'vets-website-v0-1-383' //getTagOfAppCodeLatestRelease()
+      sh "git checkout ${tag}"
 
-    sh "cd ${appCodeRepo} && git checkout ${tag}"
+      def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
+      def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
+      def currentDir = pwd()
+      def dockerArgs = "-v ${currentDir}:/application -v ${currentDir}/${contentRepo}:/${contentRepo}"
 
-    dockerImage.inside(dockerArgs) {
-      // executeBuild(dockerImage)
-      // archiveBuild()
+      dockerImage.inside(dockerArgs) {
+        // executeBuild(dockerImage)
+        // archiveBuild()
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,6 @@ appCodeRepo = 'vets-website'
 contentRepo = 'vagov-content'
 productionEnv = 'vagovdev'
 productionBuildJob = 'deploys/vets-website-vagovdev'
-latestReleaseTag = null
 
 def getTagOfAppCodeLatestRelease = {
   def github = GitHub.connect()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,16 +33,6 @@ def checkoutAppCode = {
   checkout changelog: false, poll: false, scm: scmOptions
 }
 
-def executeBuild(dockerImage) {
-  def installDependencies = "yarn install --production=false"
-  def build = "npm --no-color run build -- --buildtype=${productionEnv}"
-  def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
-
-  sh installDependencies
-  sh build
-  sh preArchive
-}
-
 def archiveBuild = {
   def awsCredentials = [[
     $class: 'UsernamePasswordMultiBinding',
@@ -102,7 +92,13 @@ node('vetsgov-general-purpose') {
 
       dockerImage.inside(dockerArgs) {
         dir ('/application') {
-          executeBuild()
+          def installDependencies = "yarn install --production=false"
+          def build = "npm --no-color run build -- --buildtype=${productionEnv}"
+          def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
+
+          sh installDependencies
+          sh build
+          sh preArchive
         }
         // archiveBuild()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ node('vetsgov-general-purpose') {
     passwordVariable: 'AWS_SECRET_KEY'
   ]]
 
-  def releaseTag, releaseCommit, dockerImage, contentCommit
+  def releaseTag, releaseCommit, dockerImage, contentCommit, tarballName
 
   stage('Rebuild Dev/Staging') {
     if (!isMaster) return
@@ -99,12 +99,19 @@ node('vetsgov-general-purpose') {
 
       withCredentials(awsCredentials) {
         def convertToTarball = "tar -C /application/build/${productionEnv} -cf /application/build/${productionEnv}.tar.bz2 ."
+
+        def tarballName = "${releaseCommit}__content-${contentCommit}"
         def uploadTarball = "\
           s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
-          s3://vetsgov-website-builds-s3-upload/${releaseCommit}__content-${contentCommit}/${productionEnv}.tar.bz2"
+          s3://vetsgov-website-builds-s3-upload/${tarballName}/${productionEnv}.tar.bz2"
 
         sh convertToTarball
-        echo uploadTarball
+        sh uploadTarball
+
+        // build job: jobName, parameters: [
+        //   booleanParam(name: 'notify_slack', value: true),
+        //   stringParam(name: 'ref', value: ref),
+        // ], wait: false
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ node('vetsgov-general-purpose') {
     sh "cd ${appCodeRepo} && git checkout ${tag}"
 
     dockerImage.inside(dockerArgs) {
-      executeBuild(dockerImage)
+      // executeBuild(dockerImage)
       // archiveBuild()
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ node('vetsgov-general-purpose') {
       // The build script will use this flag to pull the compiled app-code from the www.va.gov S3 bucket.
 
       def installDependencies = "cd /application && yarn install --production=false"
-      def build = "npm --prefix /application --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
+      def build = "npm --prefix /application --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=/${contentRepo}"
       def preArchive = "cd /application && node script/pre-archive/index.js --buildtype=${productionEnv}"
 
       sh installDependencies

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,13 +89,17 @@ node('vetsgov-general-purpose') {
     echo dockerArgs
 
     dockerImage.inside(dockerArgs) {
-      def installDependencies = "cd /application && yarn install --production=false"
-      def build = "cd /application && npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
-      def preArchive = "cd /application && node script/pre-archive/index.js --buildtype=${productionEnv}"
 
-      sh installDependencies
-      sh build
-      sh preArchive
+      dir('/application') {
+        def installDependencies = "yarn install --production=false"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
+        def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
+
+        sh installDependencies
+        sh build
+        sh preArchive
+
+      }
 
       withCredentials(awsCredentials) {
         // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,8 +87,7 @@ node('vetsgov-general-purpose') {
 
       def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
       def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-      def currentDir = pwd()
-      def dockerArgs = "-v ${currentDir}:/application -v ${currentDir}/../${contentRepo}:/${contentRepo}"
+      def dockerArgs = "-v ./:/application -v ../${contentRepo}:/${contentRepo}"
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ node('vetsgov-general-purpose') {
       checkoutAppCode()
     }
 
-    def tag = 'vets-website/v0.1.383' //getTagOfAppCodeLatestRelease()
+    def tag = 'v0.1.383' //getTagOfAppCodeLatestRelease()
     def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
     def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
     def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ node('vetsgov-general-purpose') {
       checkoutAppCode()
 
       releaseTag = 'vets-website/v0.1.383' //getTagOfAppCodeLatestRelease()
-      sh "git checkout ${tag}"
+      sh "git checkout ${releaseTag}"
 
       def imageTag = java.net.URLDecoder.decode(releaseTag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
 
@@ -88,7 +88,7 @@ node('vetsgov-general-purpose') {
 
     dockerImage.inside(dockerArgs) {
       def installDependencies = "yarn install --production=false"
-      def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
+      def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=/${contentRepo}"
       def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
       sh 'cd /application'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,8 +86,6 @@ node('vetsgov-general-purpose') {
     def currentDir = pwd()
     def dockerArgs = "-v ${currentDir}/${appCodeRepo}:/application -v ${currentDir}/${contentRepo}:/${contentRepo}"
 
-    echo dockerArgs
-
     dockerImage.inside(dockerArgs) {
 
       def installDependencies = "cd /application && yarn install --production=false"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,14 +97,13 @@ node('vetsgov-general-purpose') {
       sh preArchive
 
       withCredentials(awsCredentials) {
-        // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
         def convertToTarball = "tar -C /application/build/${productionEnv} -cf /application/build/${productionEnv}.tar.bz2 ."
-        // def uploadTarball = "\
-        //   s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
-        //   s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"
+        def uploadTarball = "\
+          s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
+          s3://vetsgov-website-builds-s3-upload/${releaseCommit}/${productionEnv}.tar.bz2"
 
         sh convertToTarball
-        // echo uploadTarball
+        echo uploadTarball
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,16 +91,15 @@ node('vetsgov-general-purpose') {
       def dockerArgs = "-v ${currentDir}:/application -v ${currentDir}/${contentRepo}:/${contentRepo}"
 
       dockerImage.inside(dockerArgs) {
-        dir ('/application') {
-          def installDependencies = "yarn install --production=false"
-          def build = "npm --no-color run build -- --buildtype=${productionEnv}"
-          def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
+        def installDependencies = "yarn install --production=false"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv}"
+        def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
-          sh installDependencies
-          sh build
-          sh preArchive
-        }
-        // archiveBuild()
+        sh 'cd /application'
+        sh installDependencies
+        sh build
+        sh preArchive
+      // archiveBuild()
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ node('vetsgov-general-purpose') {
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=/${contentRepo}"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv}"
         def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
         sh 'cd /application'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ node('vetsgov-general-purpose') {
       // The build script will use this flag to pull the compiled app-code from the www.va.gov S3 bucket.
 
       def installDependencies = "cd /application && yarn install --production=false"
-      def build = "npm --prefix /application --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=/${contentRepo}"
+      def build = "npm --prefix /application --no-color run build -- --buildtype=${productionEnv} --content-deployment"
       def preArchive = "cd /application && node script/pre-archive/index.js --buildtype=${productionEnv}"
 
       sh installDependencies

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ node('vetsgov-general-purpose') {
       checkoutAppCode()
     }
 
-    // def tag = getTagOfAppCodeLatestRelease()
+    def tag = getTagOfAppCodeLatestRelease()
     // def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
     // def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
     // def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ node('vetsgov-general-purpose') {
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv}"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=../${contentRepo}"
         def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
         sh 'cd /application'
@@ -95,7 +95,7 @@ node('vetsgov-general-purpose') {
         sh preArchive
 
         withCredentials(awsCredentials) {
-          def convertToTarball = "tar -C /build/${productionEnv} -cf /build/${productionEnv}.tar.bz2 ."
+          def convertToTarball = "tar -C build/${productionEnv} -cf build/${productionEnv}.tar.bz2 ."
           // def uploadTarball = "s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 s3://vetsgov-website-builds-s3-upload/${ref}/${productionEnv}.tar.bz2"
 
           sh convertToTarball

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ node('vetsgov-general-purpose') {
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv}"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=/${contentRepo}"
         def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
         sh 'cd /application'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,29 +83,29 @@ node('vetsgov-general-purpose') {
       dockerImage = docker.build("${appCodeRepo}:${imageTag}")
     }
 
-    // def currentDir = pwd()
-    // def dockerArgs = "-v ${currentDir}/${spp}:/application -v ${appCodeRepo}/${contentRepo}:/${contentRepo}"
+    def currentDir = pwd()
+    def dockerArgs = "-v ${currentDir}/${appCodeRepo}:/application -v ${currentDir}/${contentRepo}:/${contentRepo}"
 
-    // dockerImage.inside(dockerArgs) {
-    //   def installDependencies = "yarn install --production=false"
-    //   def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
-    //   def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
+    dockerImage.inside(dockerArgs) {
+      def installDependencies = "yarn install --production=false"
+      def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
+      def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
-    //   sh 'cd /application'
-    //   sh installDependencies
-    //   sh build
-    //   sh preArchive
+      sh 'cd /application'
+      sh installDependencies
+      sh build
+      sh preArchive
 
-    //   withCredentials(awsCredentials) {
-    //     // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-    //     def convertToTarball = "tar -C build/${productionEnv} -cf build/${productionEnv}.tar.bz2 ."
-    //     // def uploadTarball = "\
-    //     //   s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
-    //     //   s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"
+      withCredentials(awsCredentials) {
+        // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+        def convertToTarball = "tar -C build/${productionEnv} -cf build/${productionEnv}.tar.bz2 ."
+        // def uploadTarball = "\
+        //   s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
+        //   s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"
 
-    //     sh convertToTarball
-    //     // echo uploadTarball
-    //   }
+        sh convertToTarball
+        // echo uploadTarball
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,6 +86,8 @@ node('vetsgov-general-purpose') {
     def currentDir = pwd()
     def dockerArgs = "-v ${currentDir}/${appCodeRepo}:/application -v ${currentDir}/${contentRepo}:/${contentRepo}"
 
+    echo dockerArgs
+
     dockerImage.inside(dockerArgs) {
       def installDependencies = "yarn install --production=false"
       def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=/${contentRepo}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 import org.kohsuke.github.GitHub
 
-isMaster = env.BRANCH_NAME == 'fix-content-deploy'
+isMaster = env.BRANCH_NAME == 'content-deploy-fast'
 orgName = 'department-of-veterans-affairs'
 appCodeRepo = 'vets-website'
 contentRepo = 'vagov-content'
@@ -118,12 +118,12 @@ node('vetsgov-general-purpose') {
     }
   }
 
-  stage('Deploy Production') {
-    if (!isMaster) return
+  // stage('Deploy Production') {
+  //   if (!isMaster) return
 
-    // build job: productionBuildJob, parameters: [
-    //   booleanParam(name: 'notify_slack', value: true),
-    //   stringParam(name: 'ref', value: releaseCommit),
-    // ], wait: true
-  }
+  //   build job: productionBuildJob, parameters: [
+  //     booleanParam(name: 'notify_slack', value: true),
+  //     stringParam(name: 'ref', value: releaseCommit),
+  //   ], wait: true
+  // }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,9 +34,10 @@ def checkoutAppCode = {
 }
 
 def executeBuild(dockerImage) {
-  def installDependencies = "cd /application && yarn install --production=false"
-  def build = "cd /application && npm --no-color run build -- --buildtype=${productionEnv}"
-  def preArchive = "cd /application && node script/pre-archive/index.js --buildtype=${productionEnv}"
+  def installDependencies = "yarn install --production=false"
+  def build = "npm --no-color run build -- --buildtype=${productionEnv}"
+  def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
+
   sh installDependencies
   sh build
   sh preArchive
@@ -100,7 +101,9 @@ node('vetsgov-general-purpose') {
       def dockerArgs = "-v ${currentDir}:/application -v ${currentDir}/${contentRepo}:/${contentRepo}"
 
       dockerImage.inside(dockerArgs) {
-        // executeBuild(dockerImage)
+        dir ('/application') {
+          executeBuild()
+        }
         // archiveBuild()
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,8 @@ node('vetsgov-general-purpose') {
     passwordVariable: 'AWS_SECRET_KEY'
   ]]
 
+  def releaseTag, releaseCommit, dockerImage
+
   stage('Rebuild Dev/Staging') {
     if (!isMaster) return
 
@@ -72,35 +74,13 @@ node('vetsgov-general-purpose') {
     dir(appCodeRepo) {
       checkoutAppCode()
 
-      def tag = 'vets-website/v0.1.383' //getTagOfAppCodeLatestRelease()
+      releaseTag = 'vets-website/v0.1.383' //getTagOfAppCodeLatestRelease()
       sh "git checkout ${tag}"
 
-      def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
-      def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-      def currentDir = pwd()
-      def dockerArgs = "-v ${currentDir}:/application -v ${currentDir}/../${contentRepo}:/${contentRepo}"
+      def imageTag = java.net.URLDecoder.decode(releaseTag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
 
-      dockerImage.inside(dockerArgs) {
-        def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
-        def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
-
-        sh 'cd /application'
-        sh installDependencies
-        sh build
-        sh preArchive
-
-        withCredentials(awsCredentials) {
-          // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
-          def convertToTarball = "tar -C build/${productionEnv} -cf build/${productionEnv}.tar.bz2 ."
-          // def uploadTarball = "\
-          //   s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
-          //   s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"
-
-          sh convertToTarball
-          // echo uploadTarball
-        }
-      }
+      releaseCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+      dockerImage = docker.build("${appCodeRepo}:${imageTag}")
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ appCodeRepo = 'vets-website'
 contentRepo = 'vagov-content'
 productionEnv = 'vagovdev'
 productionBuildJob = 'deploys/vets-website-vagovdev'
+latestReleaseTag = null
 
 def getTagOfAppCodeLatestRelease = {
   def github = GitHub.connect()
@@ -84,20 +85,20 @@ node('vetsgov-general-purpose') {
     // every release instead. So, we need to rebuild Prod using the archive of the
     // latest release.
 
+    def imageTag = java.net.URLDecoder.decode(latestReleaseTag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
+    def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
+    def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
+
+    latestReleaseTag = getTagOfAppCodeLatestRelease()
+
     dir(contentRepo) {
       checkout scm
     }
 
     dir(appCodeRepo) {
       checkoutAppCode()
+      sh "git checkout ${latestReleaseTag}"
     }
-
-    def tag = getTagOfAppCodeLatestRelease()
-    def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
-    def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
-    def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"
-
-    sh "cd ${appCodeRepo} && git checkout ${tag}"
 
     dockerImage.inside(dockerArgs) {
       executeBuild(dockerImage)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,8 @@ node('vetsgov-general-purpose') {
     passwordVariable: 'AWS_SECRET_KEY'
   ]]
 
+  def tag = 'vets-website/v0.1.383' //getTagOfAppCodeLatestRelease()
+
   stage('Rebuild Dev/Staging') {
     if (!isMaster) return
 
@@ -72,7 +74,6 @@ node('vetsgov-general-purpose') {
     dir(appCodeRepo) {
       checkoutAppCode()
 
-      def tag = 'vets-website/v0.1.383' //getTagOfAppCodeLatestRelease()
       sh "git checkout ${tag}"
 
       def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,11 +88,11 @@ node('vetsgov-general-purpose') {
       def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
       def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
       def currentDir = pwd()
-      def dockerArgs = "-v ${currentDir}:/application -v ${currentDir}/${contentRepo}:/${contentRepo}"
+      def dockerArgs = "-v ${currentDir}:/application -v ${currentDir}/../${contentRepo}:/${contentRepo}"
 
       dockerImage.inside(dockerArgs) {
         def installDependencies = "yarn install --production=false"
-        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=/${contentRepo} --brand-consolidation-enabled"
+        def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-directory=/${contentRepo}"
         def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
 
         sh 'cd /application'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,5 +82,30 @@ node('vetsgov-general-purpose') {
       releaseCommit = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
       dockerImage = docker.build("${appCodeRepo}:${imageTag}")
     }
+
+    // def currentDir = pwd()
+    // def dockerArgs = "-v ${currentDir}/${spp}:/application -v ${appCodeRepo}/${contentRepo}:/${contentRepo}"
+
+    // dockerImage.inside(dockerArgs) {
+    //   def installDependencies = "yarn install --production=false"
+    //   def build = "npm --no-color run build -- --buildtype=${productionEnv} --content-deployment --content-directory=../${contentRepo}"
+    //   def preArchive = "node script/pre-archive/index.js --buildtype=${productionEnv}"
+
+    //   sh 'cd /application'
+    //   sh installDependencies
+    //   sh build
+    //   sh preArchive
+
+    //   withCredentials(awsCredentials) {
+    //     // def releaseCommitSha = sh(returnStdout: true, script: 'git rev-parse HEAD').trim()
+    //     def convertToTarball = "tar -C build/${productionEnv} -cf build/${productionEnv}.tar.bz2 ."
+    //     // def uploadTarball = "\
+    //     //   s3-cli put --acl-public --region us-gov-west-1 /application/build/${productionEnv}.tar.bz2 \
+    //     //   s3://vetsgov-website-builds-s3-upload/${releaseCommitSha}/${productionEnv}.tar.bz2"
+
+    //     sh convertToTarball
+    //     // echo uploadTarball
+    //   }
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,7 @@ node('vetsgov-general-purpose') {
       checkoutAppCode()
     }
 
-    def tag = 'v0.1.383' //getTagOfAppCodeLatestRelease()
+    def tag = 'vets-website-v0-1-383' //getTagOfAppCodeLatestRelease()
     def imageTag = java.net.URLDecoder.decode(tag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")
     def dockerImage = docker.build("${appCodeRepo}:${imageTag}")
     def dockerArgs = "-v ${pwd()}/${appCodeRepo}:/application -v ${pwd()}/${contentRepo}:/${contentRepo}"

--- a/assets/test.txt
+++ b/assets/test.txt
@@ -1,3 +1,5 @@
 The CMS deploy DEFINITELY works!
 
 Testing...
+
+Added at 1:20 PM, Nov. 6th

--- a/assets/test.txt
+++ b/assets/test.txt
@@ -1,1 +1,3 @@
 The CMS deploy DEFINITELY works!
+
+Testing...


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14855

This pull request implements the Content Deployment. It does this in three stages -

### 1. Rebuild Dev/Staging
- Rebuilds the latest commit of `vets-website`
- This does nothing special, or optimal. We know that the build job `testing/vets-website/master` will always check out the latest version of `vagov-content`, so this repo can piggyback off of that to rebuild the latest commit of `vets-website`.

### 2. Rebuild Production
This is a weird case. Dev/Staging should always have the latest commit, so we can rely on step 1 to update those environments. Prod reflects the latest release, however, so it's a special case. We have to rebuild the site with a local vets-website reset to the commit SHA of the latest release. The latest content will be checked out into a sibling directory. Then we can rebuild the site, upload to S3, and deploy.

- Steps:
    1. Checks out the content repo
    2. Checks out vets-website (aliases to vagov-apps)
    3. Resets the local vets-website to the tag of the latest release
    4. Rebuilds the local vets-website
    5. Uploads to S3 under the commit SHA of the tag
    6. Deploys

### 3. Deploy to production (or a spoofed environment)

## To Test
1. Define `isMaster` as -
```
isMaster = env.BRANCH_NAME == 'content-deploy-fast'
```

2. Manually set a release/SHA inside `dir(appCodeRepo) {`
```
releaseTag = 'vets-website/v0.1.383'
def imageTag = java.net.URLDecoder.decode(releaseTag).replaceAll("[^A-Za-z0-9\\-\\_]", "-")

releaseCommit = 'dab158f1e0bd5776963c4fa459a55c8237445f86'
dockerImage = docker.build("${appCodeRepo}:${imageTag}")
```
You should should choose a commit whose archive is harmless to overwrite (preferably for any environment). The release should be the latest release. This isn't necessary, but otherwise, the GitHub API caps you to a certain number of API hits per hour.

3. **Comment out the deploy step**
4. Download the archive of the commit SHA from S3 and confirm it was processed okay

Optionally, you can change the environment and build job to test even further (such as by depoying to dev.)