### PR TITLE
Patch for Heroku review instances after deprecating Vets.gov dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "scripts": {
     "vagov-apps:clone": "git clone --depth=1 https://github.com/department-of-veterans-affairs/vets-website ../vagov-apps",
     "vagov-apps:install": "cd ../vagov-apps && yarn install --production=false",
-    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry static-pages --buildtype=vagovdev --brand-consolidation-enabled",
+    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry static-pages --brand-consolidation-enabled",
     "move-output": "mv ../vagov-apps/build build",
     "preinstall": "npm run vagov-apps:clone && npm run vagov-apps:install && npm run vagov-apps:build && npm run move-output",
-    "start": "http-server build/vagovdev"
+    "start": "http-server build/localhost"
   },
   "dependencies": {
     "http-server": "^0.11.1"

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "scripts": {
     "vagov-apps:clone": "git clone --depth=1 https://github.com/department-of-veterans-affairs/vets-website ../vagov-apps",
     "vagov-apps:install": "cd ../vagov-apps && yarn install --production=false",
-    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-deployment --content-directory=${PWD}/pages --entry static-pages --brand-consolidation-enabled",
+    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-deployment --content-directory=${PWD}/pages --entry static-pages --buildtype=vagovdev --brand-consolidation-enabled",
     "move-output": "mv ../vagov-apps/build build",
     "preinstall": "npm run vagov-apps:clone && npm run vagov-apps:install && npm run vagov-apps:build && npm run move-output",
-    "start": "http-server build/localhost"
+    "start": "http-server build/vagovdev"
   },
   "dependencies": {
     "http-server": "^0.11.1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "vagov-apps:clone": "git clone --depth=1 https://github.com/department-of-veterans-affairs/vets-website ../vagov-apps",
     "vagov-apps:install": "cd ../vagov-apps && yarn install --production=false",
-    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-deployment --content-directory=${PWD}/pages --entry static-pages --buildtype=vagovdev --brand-consolidation-enabled",
+    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry static-pages --buildtype=vagovdev --brand-consolidation-enabled",
     "move-output": "mv ../vagov-apps/build build",
     "preinstall": "npm run vagov-apps:clone && npm run vagov-apps:install && npm run vagov-apps:build && npm run move-output",
     "start": "http-server build/vagovdev"


### PR DESCRIPTION
With the Vets.gov dev environment being deprecated and the content deployment being revisited, we need to remove the `--content-deployment` flag from the Heroku review instances and instead just compile the static pages bundle as usual.