### PR TITLE
Fixes Link in Burials Left Nav

### DIFF
--- a/pages/burials-memorials/replace-medals-awards-and-decorations.md
+++ b/pages/burials-memorials/replace-medals-awards-and-decorations.md
@@ -1,6 +1,6 @@
 ---
 title: Replace Medals, Awards, and Decorations
-href: https://www.cem.va.gov/recmed_records.asp
+href: https://www.archives.gov/veterans/replace-medals
 target: _blank
 order: 4
 collection: burials


### PR DESCRIPTION
The link for "Replace Medals, Awards, and Decorations is incorrect.  

The option should link here: www.archives.gov/veterans/replace-medals

This is an external link and should continue to open in a new tab/window and should have the external link icon next to it. 

## Before
![image.png](https://images.zenhubusercontent.com/59ca6a73b0222d5de4792f1d/fe648b37-377e-4fa5-88d3-69a93e368820)

## After

![image](https://user-images.githubusercontent.com/7482329/48016679-72091600-e0e9-11e8-93cd-c5cff995c0fe.png)


It now links to the correct site

### Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14483