### PR TITLE
Fixes button to eBenefits on Direct Deposit page

### DIFF
--- a/pages/change-direct-deposit-and-contact-information.md
+++ b/pages/change-direct-deposit-and-contact-information.md
@@ -18,7 +18,7 @@ Change your direct deposit and contact information for certain VA benefits onlin
     <h4 class="usa-alert-heading">You’ll need to sign in to eBenefits to change your direct deposit and contact information online.</h4>
   <p class="usa-alert-text"><br>
     To use this feature, you'll need a Premium <b>DS Logon</b> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <b>DS Logon</b> account to Premium.<br>
-      <button class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information">Go to eBenefits to Change Your Information</button>
+      <a class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information">Go to eBenefits to Change Your Information</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Background

The button to go to eBenefits on the Change Your Direct Deposit or Contact Information page does not work.

Should link to eBenefits and open in a new tab.

This PR refactors button to be an external link, in keeping with the manner in which other buttons that link to external sites, in a new tabs, do elsewhere in the codebase.

## Definition of done

- [x] Button links to eBenefits in a new tab

## Screenshot

Button now opens to the below URL, in a new tab:

![image](https://user-images.githubusercontent.com/7482329/48024918-324d2900-e0ff-11e8-96b8-b3bc411ff57a.png)

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14838