### PR TITLE
[WIP] Fix sidebar on education opt-out page

### DIFF
--- a/pages/education/opt-out-information-sharing.md
+++ b/pages/education/opt-out-information-sharing.md
@@ -15,6 +15,8 @@ widgets:
     loadingMessage: Checking your application status.
     errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
     description: Find the right VA education benefits for you, and apply to start getting help paying tuition. We can also help you find the right school or training program.
+hideFromSidebar: true
+spoke: More Resources
 ---
 
 


### PR DESCRIPTION
## Background
From [vets-gov/#14614](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14614)

> Left Nav is not loading correctly on this page:
https://preview.va.gov/education/opt-out-information-sharing/

> Given this page is not accessible from the left nav, we should remove the left nav from it. This page is intentionally not linked to from anywhere in navigation.

This PR is proposed as an interim solution until post-launch, where further work can be extended to allow for a template sans-left-navbar.

## Screenshots
### Before
![2018-11-05-163045_1037x1128_scrot](https://user-images.githubusercontent.com/11085141/48036457-275dbd00-e12e-11e8-85c8-8323df011cd6.png)

### After
![2018-11-05-190856_1172x1104_scrot](https://user-images.githubusercontent.com/11085141/48036490-48261280-e12e-11e8-9366-c55cea905290.png)

