### PR TITLE
Add file for increased disability link to sidebar

### DIFF
--- a/pages/disability/file-for-increased.md
+++ b/pages/disability/file-for-increased.md
@@ -1,0 +1,7 @@
+---
+title: File for Increased Disability
+href: /disability-benefits/apply/form-526-disability-claim/introduction
+order: 2
+spoke: Manage Benefits
+private: true
+---


### PR DESCRIPTION
Issue: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14911

Added "File for Increased Disability"  as second option in the left nav, just below Check Claim or Appeal Status.  

It should link to: https://preview.va.gov/disability-benefits/apply/form-526-disability-claim/introduction

![image.png](https://images.zenhubusercontent.com/59ca6a73b0222d5de4792f1d/8c0e31ec-f17b-4076-853b-0db4c79490e8)