### PR TITLE
Change href of link to point to non-auth page

### DIFF
--- a/pages/disability/after-you-file-claim.md
+++ b/pages/disability/after-you-file-claim.md
@@ -50,7 +50,7 @@ Find out what happens to your claim after you file for disability compensation.
 
 You don’t need to do anything unless we send you a letter asking for more information. If we schedule any exams for you, be sure not to miss them. You can check the status of your claim online. The time frame you see there may vary based on how complex your claim is.
 
-<a class="usa-button-primary" href="/track-claims">Track the Status of Your Claim</a>
+<a class="usa-button-primary" href="/claim-or-appeal-status">Track the Status of Your Claim</a>
 
 <div markdown="0"><br></div>
 


### PR DESCRIPTION
## Description

This PR updates the link on https://va.gov/disability/after-you-file-claim/ to not load the login modal. See [issue](https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14405) for more context. 