### PR TITLE
Add a redirect for the Welcome Kit

### DIFF
--- a/redirects/vets-gov-to-va-gov.yml
+++ b/redirects/vets-gov-to-va-gov.yml
@@ -622,3 +622,6 @@
 - vets_gov_src: veteran-id-card
   va_gov_dest: records/get-veteran-id-cards
   retain_path: false
+- vets_gov_src: welcome-to-va/
+  va_gov_dest: welcome-kit/
+  retain_path: false


### PR DESCRIPTION
Noted here, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/13928#issuecomment-437114031, `https://www.vets.gov/welcome-to-va/` should point to `https://www.va.gov/welcome-kit/`.