### PR TITLE
Correctly styles alert box in keeping with our style guide

### DIFF
--- a/pages/disability/va-claim-exam.md
+++ b/pages/disability/va-claim-exam.md
@@ -32,7 +32,9 @@ After you file your disability benefits claim, we may ask you to have a claim ex
 <div class="usa-alert usa-alert-warning">
 <div class="usa-alert-body">
 
-##### Be sure not to miss your scheduled exam.
+<h3 class="usa-alert-heading">
+Be sure not to miss your scheduled exam.
+</h3>
 
 If you miss your exam, we may not be able to reschedule you right away, and your claim may be delayed while you wait for a new appointment. Or we may need to rate your claim “as-is.” This means we’ll base our decision about your disability benefits only on the evidence we have in your file, which may not be enough.
 


### PR DESCRIPTION
## Background

On [VA Claim Exam (C&P Exam)](https://www.va.gov/disability/va-claim-exam/), the contextual alert title isn't aligned with the icon. 

**Desired behavior:**
The contextual alert title and icon should line up. See Alert Boxes in Formation: https://department-of-veterans-affairs.github.io/vets-design-system-documentation/design-system/components/alertboxes.html

## Screenshot

## Before fix

![image.png](https://images.zenhubusercontent.com/5b744a5479b04b75031e37c2/3b311a99-2ea8-4660-91de-d681ea18dcb3)

#### After fix

![image](https://user-images.githubusercontent.com/7482329/48227140-c2d57480-e35e-11e8-8dab-058aa0ee693b.png)


## Definition of done
 - [ ] Styles alert box in keeping with our [style guide](https://department-of-veterans-affairs.github.io/vets-design-system-documentation/design-system/components/alertboxes.html)