### PR TITLE
Add redirect for facilities

### DIFF
--- a/redirects/vets-gov-to-va-gov.yml
+++ b/redirects/vets-gov-to-va-gov.yml
@@ -625,3 +625,6 @@
 - vets_gov_src: welcome-to-va/
   va_gov_dest: welcome-kit/
   retain_path: false
+- vets_gov_src: /facilities/
+  va_gov_dest: /find-locations/
+  retain_path: true


### PR DESCRIPTION
I think maybe we had this and I removed it? We need to keep any react apps in this list that changed urls and need to retain their path.

Related to https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15019