### PR TITLE
Fixes link spacing on How to Apply for a VA Home Loan COE

### DIFF
--- a/pages/housing-assistance/home-loans/how-to-apply.md
+++ b/pages/housing-assistance/home-loans/how-to-apply.md
@@ -121,13 +121,11 @@ If you’re a **surviving spouse** who qualifies for home loan benefits, you’l
   - A copy of your marriage license, **and**
   - The Veteran’s death certificate
 
-  <br>
- [Download VA Form 21P-534EZ](https://www.vba.va.gov/pubs/forms/VBA-21P-534EZ-ARE.pdf).
-
- <br>
-
- [Find out if you qualify for home loan benefits](/housing-assistance/home-loans/eligibility/). <br />
- [Get military service records online](https://www.archives.gov/veterans/military-service-records/).
+[Download VA Form 21P-534EZ](https://www.vba.va.gov/pubs/forms/VBA-21P-534EZ-ARE.pdf).
+<br/>
+[Find out if you qualify for home loan benefits](/housing-assistance/home-loans/eligibility/).
+<br/>
+[Get military service records online](https://www.archives.gov/veterans/military-service-records/).
 
 </div>
 </li>


### PR DESCRIPTION
## Background

Expand "Surviving spouse of a Veteran who died on active duty or who had a service-connected disability."

The following links are oddly spaced:

Download VA Form 21P-534EZ.
Find out if you qualify for home loan benefits.
Get military service records online.

## Screenshot
### Before fix

![image.png](https://images.zenhubusercontent.com/5b744a5479b04b75031e37c2/306c5fd2-c1bd-4b3d-a536-c37d1c45db93)

### After fix
![image](https://user-images.githubusercontent.com/7482329/48230277-b3a6f480-e367-11e8-9fa7-18ebe66c4e5b.png)

## Definition of done

- [x] Fix spacing between these links

## Associated Issue

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15015

