### PR TITLE
Remove WBC flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "vagov-apps:clone": "git clone --depth=1 https://github.com/department-of-veterans-affairs/vets-website ../vagov-apps",
     "vagov-apps:install": "cd ../vagov-apps && yarn install --production=false",
-    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry static-pages --brand-consolidation-enabled",
+    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry static-pages",
     "move-output": "mv ../vagov-apps/build build",
     "preinstall": "npm run vagov-apps:clone && npm run vagov-apps:install && npm run vagov-apps:build && npm run move-output",
     "start": "http-server build/localhost"


### PR DESCRIPTION
Leaving the `--brand-consolidation-enabled` flag throws an error, and needs to be removed for Heroku review instances to work.

