### PR TITLE
Change references to use src/site

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -36,7 +36,7 @@ private: true
       </div>
     </div>
 </div>
-{% include "va-gov/includes/common-and-popular.html" %}
+{% include "src/site/includes/common-and-popular.html" %}
 
 <script src="/js/usa-search.js"></script>
 <script>

--- a/pages/503.html
+++ b/pages/503.html
@@ -44,7 +44,7 @@ private: true
 <body>
   <div class="container">
     <a href="/">
-      <img width="250" alt="Go to VA.gov" src="{% include "va-gov/includes/logo-350px-base64.html" %}" />
+      <img width="250" alt="Go to VA.gov" src="{% include "src/site/includes/logo-350px-base64.html" %}" />
     </a>
     <h1>VA.gov isn't working right now</h1>
     <p>We're sorry. Something went wrong on our end, and we're working to fix the problem. Please refresh this page or try again later.</p>

--- a/pages/maintenance.md
+++ b/pages/maintenance.md
@@ -18,7 +18,7 @@ private: true
       </div>
     </div>
   </div>
-   {% include va-gov/includes/common-and-popular.html %}
+   {% include src/site/includes/common-and-popular.html %}
 </div>
 
 <!-- Maintenance Page End -->


### PR DESCRIPTION
This pull request updates a few `include` statements to reference the `src/site` directory, rather than the `va-gov` directory. This is based on some restructuring to `vets-website`. After this, the `va-gov` directory can be removed from `vets-website`.

This has to be merged after https://github.com/department-of-veterans-affairs/vets-website/pull/9127.