### PR TITLE
Add some comments so that an editor knows what alert-types there are

### DIFF
--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -1,3 +1,8 @@
+# visible: if set to true, the banner will become visible on the homepage.
+# type: One of the following - info, success, warning, error
+# title: The title of the banner that will be visible to the user
+# content: The actual content of the banner. Because of the format of .yml files, this should start and end with a single quote so that you can write on multiple lines.
+
 visible: false
 type: warning
 title: Some VA.gov tools and features may not be working as expected

--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -1,7 +1,23 @@
+# ---------------------
+# Banner properties
+# ---------------------
 # visible: if set to true, the banner will become visible on the homepage.
 # type: One of the following - info, success, warning, error
 # title: The title of the banner that will be visible to the user
 # content: The actual content of the banner. Because of the format of .yml files, this should start and end with a single quote so that you can write on multiple lines.
+# 
+# ---------------------
+# Example banner
+# ---------------------
+# visible: false
+# type: warning
+# title: Some VA.gov tools and features may not be working as expected
+# content: '
+#     We’re sorry. We’re working to fix some problems with DS Logon right now.
+#     Please check back later or call MyVA311 for help: <a href="tel:18446982311">1-844-698-2311</a>.
+#     If you have hearing loss, call TTY: 711.
+#   '
+#
 
 visible: false
 type: warning


### PR DESCRIPTION
This adds some comments into the alert banner config so that editors can easily see what each property is.