### PR TITLE
Add redirects for remaining employment pages

### DIFF
--- a/redirects/vets-gov-to-va-gov.yml
+++ b/redirects/vets-gov-to-va-gov.yml
@@ -521,7 +521,7 @@
   va_gov_dest: disability-benefits/apply/form-526-disability-claim/
   retain_path: false
 - vets_gov_src: disability-benefits/track-claims
-  va_gov_dest: claim-or-appeal-status 
+  va_gov_dest: claim-or-appeal-status
   retain_path: true
 - vets_gov_src: education/apply-for-education-benefits/
   va_gov_dest: education/how-to-apply/
@@ -628,3 +628,12 @@
 - vets_gov_src: /facilities/
   va_gov_dest: /find-locations/
   retain_path: true
+- vets_gov_src: employment/commitments
+  va_gov_dest: https://www.hirevets.gov/
+  retain_path: false
+- vets_gov_src: employment/employer-list
+  va_gov_dest: careers-employment/
+  retain_path: false
+- vets_gov_src: employment/download_employers
+  va_gov_dest: careers-employment/
+  retain_path: false


### PR DESCRIPTION
This PR implements the redirects as described in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15001, and in association with the server-side redirects being removed in https://github.com/department-of-veterans-affairs/devops/pull/3699.