### PR TITLE
Remove the Vets-to-VA redirect for Terms and Conditions

### DIFF
--- a/redirects/vets-gov-to-va-gov.yml
+++ b/redirects/vets-gov-to-va-gov.yml
@@ -511,9 +511,6 @@
 - vets_gov_src: faq/
   va_gov_dest: sign-in-faq/
   retain_path: false
-- vets_gov_src: health-care/medical-information-terms-conditions/
-  va_gov_dest: health-care/
-  retain_path: false
 - vets_gov_src: beta-enrollment/claim-increase/
   va_gov_dest: disability-benefits/apply/form-526-disability-claim/
   retain_path: false


### PR DESCRIPTION
Currently, `https://www.va.gov/health-care/medical-information-terms-conditions` is inaccessible, because it was to be retired in favor of MHV terms and conditions. However, the latter is still a work in progress, so we have to re-enable this page for users to complete the MHC account creation flow.

Ticket here, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15620