### PR TITLE
Remove alias for Terms and Conditions

### DIFF
--- a/pages/health-care/index.md
+++ b/pages/health-care/index.md
@@ -8,8 +8,6 @@ concurrence:
 lastupdate:
 order: 1
 hub: health-care
-aliases:
-  - /health-care/medical-information-terms-conditions/
 promo:
   - image: /img/megamenu/health-care-illustration.png
     heading: VA Telehealth Services


### PR DESCRIPTION
This alias should have been removed in this PR, https://github.com/department-of-veterans-affairs/vagov-content/pull/181, but I missed it. The Terms and Conditions app is still necessary at the moment.