### PR TITLE
Remove redirect from /faq to /sign-in-faq

### DIFF
--- a/pages/sign-in-faq.md
+++ b/pages/sign-in-faq.md
@@ -3,8 +3,6 @@ layout: page.html
 permalink: /sign-in-faq.html
 title: Frequently Asked Questions about Signing In to VA.gov
 display_title: Frequently Asked Questions
-aliases:
-  - /faq/
 ---
 
 <div itemscope itemtype="http://schema.org/FAQPage">


### PR DESCRIPTION
This PR removes the local redirect from `/faq` to `/sign-in-faq` per this ticket, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15818.