### PR TITLE
Remove Vets.gov link

### DIFF
--- a/pages/health-care/about-va-health-benefits.md
+++ b/pages/health-care/about-va-health-benefits.md
@@ -102,7 +102,7 @@ You should also know that being signed up for VA health care meets your Affordab
   - Specialized care (including organ transplants, intensive care for mental and physical conditions, and care for traumatic injuries). <br>
   [See more VA medical and surgical specialty care services](https://www.va.gov/healthbenefits/access/specialty_care_services.asp).
 - Emergency care in a VA hospital, outpatient clinic, or Vet Center. <br>
-  [Find a VA health facility near you](https://www.vets.gov/find-locations/).
+  [Find a VA health facility near you](/find-locations/).
 - Emergency care in a non-VA hospital, clinic, or other medical setting—only under certain conditions. For us to consider covering non-VA emergency care for a non-service-connected condition, you’ll need to meet several requirements. <br>
 [Learn more about non-VA emergency medical care](https://www.va.gov/HEALTHBENEFITS/access/emergency_care.asp).
 - Mental health services to treat certain issues like posttraumatic stress disorder (PTSD), military sexual trauma (MST), depression, and substance use problems. <br>


### PR DESCRIPTION
## Page to edit
url: /health-care/about-va-health-benefits

## Origin of request (internal/stakeholder/user feedback)
Bug - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/14992

## Description of what's needed (edits/link changes/additions)
Remove the link to Vets.gov, which is causing an intermediary redirect before the user lands on Find Locations with the Vets.gov-to-VA.gov popup
