### PR TITLE
Removed usa-search.js script

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -38,7 +38,6 @@ private: true
 </div>
 {% include "src/site/includes/common-and-popular.html" %}
 
-<script src="/js/usa-search.js"></script>
 <script>
   recordEvent({ event: 'nav-404-error' });
 </script>


### PR DESCRIPTION
## Page to edit
url: pages/404.md

## Origin of request (internal/stakeholder/user feedback)
Internal. Connected to this ticket: https://github.com/department-of-veterans-affairs/vets-website/pull/9381

## Description of what's needed (edits/link changes/additions)

Removed the reference to usa-search.js in pages/404.md since we now have our own search functionality integrated into va.gov.