### PR TITLE
[Codeowners] Fix for nested files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-pages/* @bethpotts @DanielleSoCompany @peggygannon
+/pages/ @bethpotts @DanielleSoCompany @peggygannon


### PR DESCRIPTION
The codeowners file was only working properly for files at the root of `pages/`, but we want it to trigger for all files.

Per the [docs](https://help.github.com/articles/about-code-owners/), this should fix it.
```
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com

...

# In this example, @doctocat owns any file in the `/docs`
# directory in the root of your repository.
/docs/ @doctocat
```