### PR TITLE
Upgrade Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Content files for VA.gov",
   "engines": {
     "node": "8.10.0",
-    "yarn": "1.5.1"
+    "yarn": "1.12.3"
   },
   "scripts": {
     "vagov-apps:clone": "git clone --depth=1 https://github.com/department-of-veterans-affairs/vets-website ../vagov-apps",


### PR DESCRIPTION
The PR upgrade Yarn to be consistent with [`vets-website`](https://github.com/department-of-veterans-affairs/vets-website/blob/f105ed14f7606c0ec5e67b3b3201ed25871258a6/package.json#L183). It may also resolve a Heroku build error occurring during the Font Awesome upgrade.