### PR TITLE
Add code owners for homepage 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/fragments/home @ncksllvn @jbalboni @1Copenut
+/fragments/home/ @ncksllvn @jbalboni @1Copenut
 
 /pages/ @bethpotts @DanielleSoCompany @peggygannon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
+/fragments/home @ncksllvn @jbalboni @1Copenut
+
 /pages/ @bethpotts @DanielleSoCompany @peggygannon


### PR DESCRIPTION
Sometimes @Hampshire100 needs to publish a change to the homepage, such as a change to the banner or the news articles. I’m usually assigned for review, but in my absence I want to make sure other engineers are aware. Usually these changes have to be published same day. 