### PR TITLE
Add #sign-in-issue to open accordion switch

### DIFF
--- a/pages/sign-in-faq.md
+++ b/pages/sign-in-faq.md
@@ -392,6 +392,9 @@ display_title: Frequently Asked Questions
     case '#what-is-idme':
       openAccordion('faq-security-2');
       break;
+    case '#sign-in-issue':
+      openAccordion('faq-signinissue-0');
+      break;
   }
 })();
 </script>


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/sign-in-faq/

## Description of what's needed (edits/link changes/additions)

We are linking to the sign in FAQ if the user encounters an error signing it.  Upon arriving on the faq page, the first question in the "Common issues with signing in to VA.gov" should be auto expanded. Add additional JS code to auto expand accordion based on URL hash