### PR TITLE
[Bug] axe-core issue with accordion for AMA pages

### DIFF
--- a/pages/decision-reviews/higher-level-review.md
+++ b/pages/decision-reviews/higher-level-review.md
@@ -119,7 +119,8 @@ Janesville, WI 53547-4444<br>
 
 </p>
 
-<ul class="usa-accordion" aria-multiselectable="true">
+<ul class="usa-accordion process-accordion">
+  <li>
   <button class="usa-button-unstyled usa-accordion-button" 
     aria-controls="VA-other-benefit-addresses">Find addresses for other benefit types</button>
     <div id="VA-other-benefit-addresses" class="usa-accordion-content" >
@@ -228,6 +229,7 @@ form.<br>
 
 </div>
     </div>
+    </li>
 </ul>
 
 **In person**

--- a/pages/decision-reviews/supplemental-claim.md
+++ b/pages/decision-reviews/supplemental-claim.md
@@ -93,7 +93,8 @@ Janesville, WI 53547-4444<br>
 
 </p>
 
-<ul class="usa-accordion" aria-multiselectable="true">
+<ul class="usa-accordion process-accordion">
+  <li>
   <button class="usa-button-unstyled usa-accordion-button" 
     aria-controls="VA-other-benefit-addresses">Find addresses for other benefit types</button>
     <div id="VA-other-benefit-addresses" class="usa-accordion-content" >
@@ -202,6 +203,7 @@ form.<br>
 
 </div>
     </div>
+    </li>
 </ul>
 
 **In person**


### PR DESCRIPTION
## Page to edit
url: 
```
/decision-reviews/supplemental-claim/
/decision-reviews/higher-level-review/
```
## Origin of request (internal/stakeholder/user feedback)
internal

## Description of what's needed (edits/link changes/additions)
This PR fixes the axe-core bug found in https://github.com/department-of-veterans-affairs/vets.gov-team/issues/16981 where the `process-accordion` was failing the jenkins build.

**Solution**: took out `area-multiselectable` property and added an `<li>`.

I also added a class for proper styling in `vets-website` repo in `merger.scss`.


