### PR TITLE
Add page for disability v2 app, remove old page

### DIFF
--- a/pages/disability/file-disability-claim-form-21-526ez.md
+++ b/pages/disability/file-disability-claim-form-21-526ez.md
@@ -12,6 +12,6 @@ id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     <li><a href="/">Home</a></li>
     <li><a href="/disability/">Disability Benefits</a></li>
-    <li><a aria-current="page" href="/disability-benefits/apply/form-526-all-claims/">File for Disability Compensation</a></li>
+    <li><a aria-current="page" href="/disability/file-disability-claim-form-21-526ez/">File for Disability Compensation</a></li>
   </ul>
 </nav>


### PR DESCRIPTION
*Note:* The diff makes it difficult to tell, but the existing page was _deleted_, renamed, and recreated (i.e., 'moved') in a different directory

## Page to edit
url: /disability-benefits/apply/form-526-all-claims

## Origin of request (internal/stakeholder/user feedback)
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/15793

## Description of what's needed (edits/link changes/additions)
1.) Remove current path / page for the v2 526 form
2.) Add a new path / page for the v2 526 form, at `disability/file-disability-claim-form-21-526ez/`
3.) Navigation breadcrumb link for the 526 v2 form needs to reflect the new URL

Redirects from the old to new url will be handled in a separate devops PR

Related PRs:
Devops: https://github.com/department-of-veterans-affairs/devops/pull/4190
Website: https://github.com/department-of-veterans-affairs/vets-website/pull/9605
