### PR TITLE
[Appeals] Add Staging-only page

### DIFF
--- a/pages/dst/index.md
+++ b/pages/dst/index.md
@@ -1,0 +1,14 @@
+---
+layout: page-breadcrumbs.html
+template: detail-page
+title: Appeals Sandbox
+display_title: Appeals Sandbox
+---
+
+<div class="va-introtext">
+Example introductory text.
+</div>
+
+<script>
+  document.writeln('<p>This is a paragraph written by JavaScript.</p>');
+</script>

--- a/pages/dst/index.md
+++ b/pages/dst/index.md
@@ -1,8 +1,16 @@
 ---
+# Page setup.
 layout: page-breadcrumbs.html
 template: detail-page
+
+# The title of the tab.
 title: Appeals Sandbox
+
+# The <h1> visible on the page
 display_title: Appeals Sandbox
+
+# This line indicates that this page is not to be built to production (www.va.gov)
+vagovprod: false
 ---
 
 <div class="va-introtext">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1915775/53589217-d64e5a80-3b5c-11e9-9122-702bc1192e7a.png)

## Page to edit
url: /dst

## Origin of request (internal/stakeholder/user feedback)
Appeals team

> We’re looking to help set up a one page demo with live staging url that the appeals team can use. We landed on having them create a page in `vagov-content` where they could write vanilla inline JS and have the page gated to the staging environment.

## Description of what's needed (edits/link changes/additions)
A page at `/dst` that builds to Staging only
