### PR TITLE
Add production flag to front matter doc.

### DIFF
--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -200,4 +200,4 @@ relatedlinks:
 
 ### Production flag
 
-Metadata to indicate whether page should be included in production build and deploy pipeline. Defaults to `true` if absent. Useful for creating one-time prototype pages that should only be depoloyed on staging (e.g. this [sandbox for an appeals tool](https://github.com/department-of-veterans-affairs/vagov-content/blob/d5ce4f9ce0c3fc178a9856512829667933cff2df/pages/dst/index.md)).
+Metadata to indicate whether page should be included in production build and deploy pipeline. Defaults to `true` if absent. Useful for creating one-time prototype pages that should only be depoloyed on staging (e.g. this [sandbox for an appeals tool](https://github.com/department-of-veterans-affairs/vagov-content/blob/d5ce4f9ce0c3fc178a9856512829667933cff2df/pages/dst/index.md)). For more details, check out our [main documentation](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Work%20Practices/Engineering/Front%20End%20Feature%20Flags.md) on using front end feature flags.

--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -33,6 +33,7 @@ relatedlinks:
     - url:
       title:
       description:
+vagovprod:
 ---
 ```
 
@@ -49,6 +50,7 @@ Jump to:
 - [Plain language certification](/front-matter.md#plain-language-certification)
 - [Collections, children, and ordering](/front-matter.md#collections-children-and-ordering)
 - [Major vs. Related links](/front-matter.md#major-vs-related-links)
+- [Production flag](/front-matter.md#production-flag)
 
 ### Layout
 
@@ -195,3 +197,7 @@ relatedlinks:
       title: Link 4
       description:
 ```
+
+### Production flag
+
+Metadata to indicate whether page should be included in production build and deploy pipeline. Defaults to `true` if absent. Useful for creating one-time prototype pages that should only be depoloyed on staging (e.g. this [sandbox for an appeals tool](https://github.com/department-of-veterans-affairs/vagov-content/blob/d5ce4f9ce0c3fc178a9856512829667933cff2df/pages/dst/index.md)).


### PR DESCRIPTION
## Page to edit
n/a

## Origin of request (internal/stakeholder/user feedback)
Internal. Documenting what happened [here](https://github.com/department-of-veterans-affairs/vagov-content/pull/283).

## Description of what's needed (edits/link changes/additions)
Adding documentation on `vagovprod` to front matter documentation. 
