### PR TITLE
Add redirect from /decision-review to /decision-reviews

### DIFF
--- a/pages/decision-reviews/index.md
+++ b/pages/decision-reviews/index.md
@@ -17,6 +17,10 @@ relatedlinks:
     - url: "/decision-reviews/fiduciary-claims/"
       title: Fiduciary Claims
       description: If you have a fiduciary claim, find out how to request a decision review.
+
+# Temporary, see https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17108
+aliases:
+  - /decision-review
 ---
 <br>
 <div itemprop="description" class="va-introtext">


### PR DESCRIPTION
This should be done on the server, but became more complicated than expected. See linked ticket for details.

## Page to edit
url: /decision-reviews

## Origin of request (internal/stakeholder/user feedback)
See https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17108

## Description of what's needed (edits/link changes/additions)
Redirect
