### PR TITLE
Remove bottom padding between content and major links section

### DIFF
--- a/pages/careers-employment/vocational-rehabilitation.md
+++ b/pages/careers-employment/vocational-rehabilitation.md
@@ -5,37 +5,38 @@ display_title: Vocational Rehab and Employment
 permalink: /employment/vocational-rehab-and-employment/index.html
 source: http://www.benefits.va.gov/VRE/
 template: detail-page
+no_article_bottom_padding: true
 spoke: Get Benefits
 children: vre
 order: 1
 majorlinks:
   - heading: For Servicemembers and Veterans with Service-Connected Disabilities
     links:
-    - url: /careers-employment/vocational-rehabilitation/programs/
-      title: VR&E Programs for Servicemembers and Veterans
-      description: Explore VR&E support-and-services tracks for help learning new skills, finding a new job, starting a business, getting educational counseling, or returning to your former job.
-    - url: /careers-employment/vocational-rehabilitation/eligibility/
-      title: Eligibility
-      description: Find out if you can get VR&E benefits and services as a Servicemember or Veteran.
-    - url: /careers-employment/vocational-rehabilitation/how-to-apply/
-      title: How to Apply
-      description: Find out how to apply for VR&amp;E benefits and services as a Servicemember or Veteran.    
-    - url: /careers-employment/vocational-rehabilitation/ides/
-      title: Accessing VR&E through the Integrated Disability Evaluation System (IDES)
-      description: If you're wounded, injured, or fall ill while serving and can't perform your duties, find out how you can access VR&E services as soon as possible through IDES.    
+      - url: /careers-employment/vocational-rehabilitation/programs/
+        title: VR&E Programs for Servicemembers and Veterans
+        description: Explore VR&E support-and-services tracks for help learning new skills, finding a new job, starting a business, getting educational counseling, or returning to your former job.
+      - url: /careers-employment/vocational-rehabilitation/eligibility/
+        title: Eligibility
+        description: Find out if you can get VR&E benefits and services as a Servicemember or Veteran.
+      - url: /careers-employment/vocational-rehabilitation/how-to-apply/
+        title: How to Apply
+        description: Find out how to apply for VR&amp;E benefits and services as a Servicemember or Veteran.
+      - url: /careers-employment/vocational-rehabilitation/ides/
+        title: Accessing VR&E through the Integrated Disability Evaluation System (IDES)
+        description: If you're wounded, injured, or fall ill while serving and can't perform your duties, find out how you can access VR&E services as soon as possible through IDES.
   - heading: For Family Members of Servicemembers and Veterans with Service-Connected Disabilities
     links:
-    - url: /careers-employment/dependent-benefits/
-      title: Dependent Family Members
-      description: Find out if you're eligible for certain counseling services, training, and education benefits.
+      - url: /careers-employment/dependent-benefits/
+        title: Dependent Family Members
+        description: Find out if you're eligible for certain counseling services, training, and education benefits.
   - heading: More Helpful Resources
     links:
-    - url: /careers-employment/vetsuccess-on-campus/
-      title: VetSuccess on Campus
-      description: Find out if our counselors can help you transition from military to college life.
-    - url: /careers-employment/veteran-resources/
-      title: External Resources
-      description: Get links to more resources outside VA that can help you in your job search.
+      - url: /careers-employment/vetsuccess-on-campus/
+        title: VetSuccess on Campus
+        description: Find out if our counselors can help you transition from military to college life.
+      - url: /careers-employment/veteran-resources/
+        title: External Resources
+        description: Get links to more resources outside VA that can help you in your job search.
 aliases:
   - /employment/vocational-rehab-and-employment/
 ---

--- a/pages/careers-employment/vocational-rehabilitation/programs.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs.md
@@ -4,25 +4,26 @@ title: Vocational Rehab Programs for Veterans and Servicemembers
 display_title: Programs
 order: 1
 template: detail-page
+no_article_bottom_padding: true
 children: vreServiceDisabled
 majorlinks:
   - heading:
     links:
-    - url: /careers-employment/vocational-rehabilitation/programs/reemployment/
-      title: Reemployment Track
-      description: You may have the right to return to the civilian job you held before you deployed. Find out how we can help with this process.
-    - url: /careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment/
-      title: Rapid Access to Employment Track
-      description: If you want a job that matches your existing skills, find out if you can get employment counseling and job-search support.
-    - url: /careers-employment/vocational-rehabilitation/programs/self-employment/
-      title: Self-Employment Track
-      description: If you’re a Servicemember or Veteran with a service-connected disability, find out how we can help you start your own business.
-    - url: /careers-employment/vocational-rehabilitation/programs/long-term-services/
-      title: Employment through Long-Term Services Track
-      description: Find out if you may be eligible for vocational training to help you develop new job skills.
-    - url: /careers-employment/vocational-rehabilitation/programs/independent-living/
-      title: Independent Living Track
-      description: Learn about services that can help you live as independently as possible if you can't return to work right away.
+      - url: /careers-employment/vocational-rehabilitation/programs/reemployment/
+        title: Reemployment Track
+        description: You may have the right to return to the civilian job you held before you deployed. Find out how we can help with this process.
+      - url: /careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment/
+        title: Rapid Access to Employment Track
+        description: If you want a job that matches your existing skills, find out if you can get employment counseling and job-search support.
+      - url: /careers-employment/vocational-rehabilitation/programs/self-employment/
+        title: Self-Employment Track
+        description: If you’re a Servicemember or Veteran with a service-connected disability, find out how we can help you start your own business.
+      - url: /careers-employment/vocational-rehabilitation/programs/long-term-services/
+        title: Employment through Long-Term Services Track
+        description: Find out if you may be eligible for vocational training to help you develop new job skills.
+      - url: /careers-employment/vocational-rehabilitation/programs/independent-living/
+        title: Independent Living Track
+        description: Learn about services that can help you live as independently as possible if you can't return to work right away.
 aliases:
   - /employment/vocational-rehab-and-employment/service-disabled/
 ---

--- a/pages/health-care/health-needs-conditions/health-issues-related-to-service-era.md
+++ b/pages/health-care/health-needs-conditions/health-issues-related-to-service-era.md
@@ -7,33 +7,34 @@ description: Learn about Veterans health issues that may be related to where and
 concurrence: complete
 lastupdate: 2017-06-28
 order: 1
+no_article_bottom_padding: true
 aliases:
   - /health-care/health-conditions/conditions-related-to-service-era/
 children: healthCareServiceRelated
 majorlinks:
   - heading:
     links:
-    - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom/
-      title: Operation Enduring Freedom in Afghanistan
-      description: October 7, 2001 to present
-    - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war/
-      title: Iraq War—Operation Iraqi Freedom and Operation New Dawn
-      description: March 19, 2003—December 15, 2011
-    - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war/
-      title: Gulf War—Operation Desert Shield and Desert Storm
-      description: August 2, 1990—present
-    - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war/
-      title: Cold War Era
-      description: 1945—1991
-    - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war/
-      title: Vietnam War
-      description: November 1, 1965—April 30, 1975
-    - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war/
-      title: Korean War
-      description: June 25, 1950—July 27, 1953
-    - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii/
-      title: World War II
-      description: September 1, 1939—September 2, 1945
+      - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/operation-enduring-freedom/
+        title: Operation Enduring Freedom in Afghanistan
+        description: October 7, 2001 to present
+      - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/iraq-war/
+        title: Iraq War—Operation Iraqi Freedom and Operation New Dawn
+        description: March 19, 2003—December 15, 2011
+      - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/gulf-war/
+        title: Gulf War—Operation Desert Shield and Desert Storm
+        description: August 2, 1990—present
+      - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/cold-war/
+        title: Cold War Era
+        description: 1945—1991
+      - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/vietnam-war/
+        title: Vietnam War
+        description: November 1, 1965—April 30, 1975
+      - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/korean-war/
+        title: Korean War
+        description: June 25, 1950—July 27, 1953
+      - url: /health-care/health-needs-conditions/health-issues-related-to-service-era/world-war-ii/
+        title: World War II
+        description: September 1, 1939—September 2, 1945
 ---
 
 <div class="va-introtext">

--- a/pages/life-insurance/options-eligibility.md
+++ b/pages/life-insurance/options-eligibility.md
@@ -3,50 +3,50 @@ layout: page-breadcrumbs.html
 title: About VA Insurance Options and Eligibility
 display_title: Options and Eligibility
 description: If you're a Veteran, Servicemember, or the spouse or dependent child of a Servicemember, find out which VA life insurance program may be right for you. If you're ending your active-duty service, in some cases you must act within 120 days of leaving the military to ensure no lapse in coverage.
-concurrence: 
+concurrence:
 template: detail-page
+no_article_bottom_padding: true
 children: lifeInsuranceOptions
 order: 1
 spoke: Get Benefits
 majorlinks:
   - heading: VA Life Insurance Options
     links:
-    - url: /life-insurance/options-eligibility/sgli/
-      title: Servicemembers’ Group Life Insurance (SGLI) 
-      description: Get group life insurance while you’re serving.
-    - url: /life-insurance/options-eligibility/fsgli/ 
-      title: Family Servicemembers’ Group Life Insurance (FSGLI) 
-      description: Add coverage for your spouse and dependent children (children who rely on you for financial support).
-    - url: /life-insurance/options-eligibility/tsgli/ 
-      title: Traumatic Injury Protection Program (TSGLI) 
-      description: Get short-term financial support to help you recover from a severe injury.
-    - url: /life-insurance/options-eligibility/vgli/ 
-      title: Veterans’ Group Life Insurance (VGLI) 
-      description: Get group life insurance once you’ve ended your service. 
-    - url: /life-insurance/options-eligibility/s-dvi/ 
-      title: Service-Disabled Veterans Insurance (S-DVI) 
-      description: If you’re disabled because of an injury or illness caused—or made worse—by your active service, continue your life insurance beyond 2 years after you leave the military.
-    - url: /life-insurance/options-eligibility/vmli/
-      title: Veterans’ Mortgage Life Insurance (VMLI)
-      description: If you have a severe service-connected disability, get mortgage protection insurance for a home that’s been adapted to meet your needs.
+      - url: /life-insurance/options-eligibility/sgli/
+        title: Servicemembers’ Group Life Insurance (SGLI)
+        description: Get group life insurance while you’re serving.
+      - url: /life-insurance/options-eligibility/fsgli/
+        title: Family Servicemembers’ Group Life Insurance (FSGLI)
+        description: Add coverage for your spouse and dependent children (children who rely on you for financial support).
+      - url: /life-insurance/options-eligibility/tsgli/
+        title: Traumatic Injury Protection Program (TSGLI)
+        description: Get short-term financial support to help you recover from a severe injury.
+      - url: /life-insurance/options-eligibility/vgli/
+        title: Veterans’ Group Life Insurance (VGLI)
+        description: Get group life insurance once you’ve ended your service.
+      - url: /life-insurance/options-eligibility/s-dvi/
+        title: Service-Disabled Veterans Insurance (S-DVI)
+        description: If you’re disabled because of an injury or illness caused—or made worse—by your active service, continue your life insurance beyond 2 years after you leave the military.
+      - url: /life-insurance/options-eligibility/vmli/
+        title: Veterans’ Mortgage Life Insurance (VMLI)
+        description: If you have a severe service-connected disability, get mortgage protection insurance for a home that’s been adapted to meet your needs.
 relatedlinks:
   - heading: More information about your benefits
     links:
-    - url: /life-insurance/manage-your-policy/
-      title: Access Your Policy Online
-      description: Already have VA life insurance? Access your policy online.
-    - url: /life-insurance/totally-disabled-or-terminally-ill/
-      title: Claims for Disabled and Terminally Ill Policyholders
-      description: If you become totally disabled or terminally ill, find out if you can get certain benefits.
+      - url: /life-insurance/manage-your-policy/
+        title: Access Your Policy Online
+        description: Already have VA life insurance? Access your policy online.
+      - url: /life-insurance/totally-disabled-or-terminally-ill/
+        title: Claims for Disabled and Terminally Ill Policyholders
+        description: If you become totally disabled or terminally ill, find out if you can get certain benefits.
 aliases:
   - /life-insurance/options-and-eligibility/
 ---
 
 <div class="va-introtext">
 
-Are you a Servicemember, Veteran, or spouse or dependent child of a Servicemember? Find out which life insurance programs may be right for you. 
+Are you a Servicemember, Veteran, or spouse or dependent child of a Servicemember? Find out which life insurance programs may be right for you.
 
 </div>
 
-**Are you ending your military tour of duty soon?** You’ll need to get new coverage quickly. In some cases, you must act within 120 days of leaving the military to ensure no lapse in coverage. 
-
+**Are you ending your military tour of duty soon?** You’ll need to get new coverage quickly. In some cases, you must act within 120 days of leaving the military to ensure no lapse in coverage.


### PR DESCRIPTION
## Page to edit
urls: 
- /health-care/health-needs-conditions/health-issues-related-to-service-era/
- /life-insurance/options-eligibility/
- /careers-employment/vocational-rehabilitation/
- /careers-employment/vocational-rehabilitation/programs/



## Origin of request (internal/stakeholder/user feedback)
internal.  https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/14994

## Description of what's needed (edits/link changes/additions)

Added front matter flag `no_article_bottom_padding` to page. When set to true, it removes the default `padding-bottom: 3em` property set to the `article` class

**before**:
![Screen Shot 2019-03-13 at 3 18 18 PM](https://user-images.githubusercontent.com/11021491/54307966-5c2dc500-45a3-11e9-99cc-e59b6d61b3e5.png)

**after**: 
![Screen Shot 2019-03-13 at 3 18 36 PM](https://user-images.githubusercontent.com/11021491/54307975-5fc14c00-45a3-11e9-9f06-977a85df1781.png)

More info on edits to the page layout on `vets-website` found in this PR: https://github.com/department-of-veterans-affairs/vets-website/compare/fix-article-content-bottom-padding-14994?expand=1

