### PR TITLE
Move class declaration for consistency with other alerts.

### DIFF
--- a/pages/health-care/schedule-view-va-appointments.md
+++ b/pages/health-care/schedule-view-va-appointments.md
@@ -47,7 +47,7 @@ With our VA Appointments tools, you can schedule some VA health care appointment
         <p><strong>To connect with a Veterans Crisis Line responder anytime day or night:</strong></p>
         <ul>
              <li>Call <a href="tel:+18002738255">1-800-273-8255</a>, then press 1.</li>
-          <li><a class="no-external-icon" href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/">Start a confidential Veterans Chat</a>.</li>
+          <li><a href="https://www.veteranscrisisline.net/ChatTermsOfService.aspx?account=Veterans%20Chat/" class="no-external-icon">Start a confidential Veterans Chat</a>.</li>
            <li>Text <a href="sms:838255">838255</a>.</li>
            <li>If you have hearing loss, call TTY: <a href="tel:+18007994889">1-800-799-4889</a>.
            </ul>


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/health-care/schedule-view-va-appointments/

## Origin of request (internal/stakeholder/user feedback)
developer: CMS Migration

## Description of what's needed (edits/link changes/additions)
The migration script expects alerts with the same name (heading) to be identical across all of the pages where it is used. On other pages, the "How do I talk to someone right now?" alert has the class attribute after the href on the chat link.

This is an internal (html) change only. Nothing about the page should be different.
