### PR TITLE
Change all <b> tags to <strong> tags in health care hub content.

### DIFF
--- a/pages/health-care/about-va-health-benefits.md
+++ b/pages/health-care/about-va-health-benefits.md
@@ -227,7 +227,7 @@ These services are **not** included in your VA medical benefits package:
 <div itemprop="text">
 We’ll fill prescriptions by a non-VA provider only if you meet all the requirements listed below.
 
-<b>All of these must be true</b>:
+<strong>All of these must be true</strong>:
 
 - You’re enrolled in VA health care
 - You have an assigned VA primary care provider

--- a/pages/health-care/after-you-apply.md
+++ b/pages/health-care/after-you-apply.md
@@ -147,7 +147,7 @@ VA Health Eligibility Center (HEC) <br>
 2957 Clairmont Road <br>
 Atlanta, GA 30329<br>
 </p>
-<b>Note</b>: Canceling your enrollment in VA health care may impact your health care coverage requirements under the Affordable Care Act if you don’t have other health care.
+<strong>Note</strong>: Canceling your enrollment in VA health care may impact your health care coverage requirements under the Affordable Care Act if you don’t have other health care.
 
 You may reapply at any time. But please note that we’ll consider you a new applicant when you reapply. We’ll base your eligibility on the eligibility requirements at that time.
 

--- a/pages/health-care/eligibility.md
+++ b/pages/health-care/eligibility.md
@@ -104,15 +104,15 @@ Yes. You may qualify for enhanced eligibility status (meaning you’ll be placed
       <a href="https://www.va.gov/vaforms/medical/pdf/1010EZ-fillable.pdf">Obtenga la Forma VA 10-10EZ</a>.<br>
       Usted o alguien con poder legal para representarlo tiene que firmar la forma, e incluir la fecha en que fué firmada.<br>
       <ul>
-        <li><b>Si esta usando un poder legal</b>, tendra que incluir una copia de la forma con su solicitud.</li>
-        <li><b>Si firma con una X</b>, 2 personas que usted conoce tienen que tambien firmar acertando que lo vieron firmar la forma.</li>
+        <li><strong>Si esta usando un poder legal</strong>, tendra que incluir una copia de la forma con su solicitud.</li>
+        <li><strong>Si firma con una X</strong>, 2 personas que usted conoce tienen que tambien firmar acertando que lo vieron firmar la forma.</li>
       </ul>
-      <b>Puede mandar su solicitud por correo a esta dirección:</b><br>
+      <strong>Puede mandar su solicitud por correo a esta dirección:</strong><br>
       <p class="va-address-block">
         Health Eligibility Center<br>
         2957 Clairmont Rd., Suite 200<br>
         Atlanta, GA 30329</p>
-      <b>Para llenar su solicitude en persona</b>, encuetre el Centro Médico de Veteranos mas cercano en esta liga:<br>
+      <strong>Para llenar su solicitude en persona</strong>, encuetre el Centro Médico de Veteranos mas cercano en esta liga:<br>
       <a href="/find-locations/?facilityType=health">Encuentre el Centro o Clínica de Veteranos mas cercano a usted</a>.<br>
       O reciba ayuda por medio del Departmaneto de Veteranos de su estado.<br>
       <a href="https://www.va.gov/statedva.htm">Encuentre el Departamento de Veteranos de su estado</a>.

--- a/pages/health-care/family-caregiver-benefits/champva.md
+++ b/pages/health-care/family-caregiver-benefits/champva.md
@@ -47,9 +47,9 @@ There are other factors that may affect whether you or other family members qual
       <button class="usa-button-unstyled usa-accordion-button" aria-controls="expecting">A new or expectant parent</button>
       <div id="expecting" class="usa-accordion-content">
         <p>If you’re expecting a baby, you’ll need to take the 2 steps listed below before you can apply for CHAMPVA for your newborn.</p>
-        <p><b>You’ll need to:</b></p>
+        <p><strong>You’ll need to:</strong></p>
         <ul>
-          <li>Get a Social Security number for your baby by applying at the nearest Social Security Administration office, <b>and</b></li>
+          <li>Get a Social Security number for your baby by applying at the nearest Social Security Administration office, <strong>and</strong></li>
           <li>Set up the baby’s status as a dependent of the Veteran sponsor by contacting your nearest VA regional benefit office.</li>
         </ul>
         <p>Medical claims can’t be paid until you sign your baby up under CHAMPVA, so please get them a Social Security number and set their status as a dependent as soon as possible.</p>
@@ -60,8 +60,8 @@ There are other factors that may affect whether you or other family members qual
     <li>
       <button class="usa-button-unstyled usa-accordion-button" aria-controls="spouse">A surviving spouse who’s currently remarried</button>
       <div id="spouse" class="usa-accordion-content">
-        <p><b>If you’re the surviving spouse of a qualifying CHAMPVA sponsor and you remarry before age 55,</b> you no longer qualify for CHAMPVA as of midnight on the date of your remarriage.</p>
-        <p><b>If you remarry on or after your 55th birthday,</b> you can keep your CHAMPVA benefits.</p>
+        <p><strong>If you’re the surviving spouse of a qualifying CHAMPVA sponsor and you remarry before age 55,</strong> you no longer qualify for CHAMPVA as of midnight on the date of your remarriage.</p>
+        <p><strong>If you remarry on or after your 55th birthday,</strong> you can keep your CHAMPVA benefits.</p>
       </div>
     </li>
     <li>
@@ -87,10 +87,10 @@ There are other factors that may affect whether you or other family members qual
     <li>
       <button class="usa-button-unstyled usa-accordion-button" aria-controls="caregiver">A primary family caregiver of a Veteran with injuries and/or disabilities </button>
       <div id="caregiver" class="usa-accordion-content">
-        <p><b>If you’re a family member caring for a Veteran with disabilities,</b> and you’re not entitled to care or services through another health plan, you may qualify for CHAMPVA.</p>
+        <p><strong>If you’re a family member caring for a Veteran with disabilities,</strong> and you’re not entitled to care or services through another health plan, you may qualify for CHAMPVA.</p>
         <p><a href='https://www.va.gov/COMMUNITYCARE/docs/pubfiles/factsheets/FactSheet_11-01.pdf'>Download a fact sheet on CHAMPVA for primary family caregivers</a>.</p>
         <p><a href='https://www.va.gov/COMMUNITYCARE/programs/caregiver/index.asp'>Get more information about CHAMPVA for primary family caregivers</a>.</p>
-        <p><b>If the Veteran you’re caring for was seriously injured in the line of duty on or after September 11, 2001,</b> you may qualify for health care benefits and other caregiver support through the Program of Comprehensive Assistance to Family Caregivers.</p>
+        <p><strong>If the Veteran you’re caring for was seriously injured in the line of duty on or after September 11, 2001,</strong> you may qualify for health care benefits and other caregiver support through the Program of Comprehensive Assistance to Family Caregivers.</p>
         <p><a href='/health-care/family-caregiver-benefits/comprehensive-assistance'>Find out if you qualify for this program and how to apply</a>.</p>
       </div>
     </li>
@@ -98,14 +98,14 @@ There are other factors that may affect whether you or other family members qual
       <button class="usa-button-unstyled usa-accordion-button" aria-controls="champva">A CHAMPVA beneficiary who’s 65 years old or older—or who qualifies for Medicare at any age</button>
       <div id="champva" class="usa-accordion-content">
         <p>CHAMPVA is always the second payer to Medicare. Here are some requirements you need to know:</p>
-        <p><b>If you’re under 65 years old,</b> you’re eligible for CHAMPVA if you meet both of the requirements below.</br>
-      <b>Both of these must be true. You:</b></p>
+        <p><strong>If you’re under 65 years old,</strong> you’re eligible for CHAMPVA if you meet both of the requirements below.</br>
+      <strong>Both of these must be true. You:</strong></p>
         <ul>
-          <li>Have both Medicare Parts A and B, <b>and</b></li>
+          <li>Have both Medicare Parts A and B, <strong>and</strong></li>
           <li>Are otherwise eligible for CHAMPVA</li>
           </ul>
-        <p><b>If you’re 65 years old or older,</b> you’re eligible for CHAMPVA if you’re eligible for Medicare. If you turned 65 before June 5, 2001, and you’re entitled to either Medicare Part A or B, you’ll also need to enroll in Medicare Part B to be eligible for CHAMPVA.</p>
-        <p><b>Note:</b> You don’t need to enroll in Medicare Part D to qualify for CHAMPVA.</p>
+        <p><strong>If you’re 65 years old or older,</strong> you’re eligible for CHAMPVA if you’re eligible for Medicare. If you turned 65 before June 5, 2001, and you’re entitled to either Medicare Part A or B, you’ll also need to enroll in Medicare Part B to be eligible for CHAMPVA.</p>
+        <p><strong>Note:</strong> You don’t need to enroll in Medicare Part D to qualify for CHAMPVA.</p>
 
 <p><a href='https://www.va.gov/COMMUNITYCARE/docs/pubfiles/factsheets/FactSheet_01-12.pdf'>Download a fact sheet on Medicare and CHAMPVA</a>.</p>       </div>
 

--- a/pages/health-care/get-medical-records.md
+++ b/pages/health-care/get-medical-records.md
@@ -29,7 +29,7 @@ Our online tools can help you view, organize, and share your VA medical records 
 <div class="va-sign-in-alert usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">You'll need to go to eBenefits to authorize us to share your health information through the Veterans Health Information Exchange.</h4><br>
-    <p class="usa-alert-text">To use this feature, you'll need a Premium <b>DS Logon</b> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <b>DS Logon</b> account to Premium.<br>
+    <p class="usa-alert-text">To use this feature, you'll need a Premium <strong>DS Logon</strong> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <strong>DS Logon</strong> account to Premium.<br>
       <a class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/vapii" target="_blank">Go to eBenefits</a>
     </p>
   </div>

--- a/pages/health-care/health-needs-conditions/mental-health.md
+++ b/pages/health-care/health-needs-conditions/mental-health.md
@@ -280,10 +280,10 @@ You can also get support from resources offered by other government departments 
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="resources-veterans">Mental Health Resources for Veterans, Servicemembers, and Families</button>
 <div id="resources-veterans" class="usa-accordion-content">
 
-<b>[Military OneSource](https://www.militaryonesource.mil/mental-health)</b><br>
+<strong>[Military OneSource](https://www.militaryonesource.mil/mental-health)</strong><br>
 This free service provides expert support to connect military personnel and their families with the best available resources to fit their needs. For support, visit the Military OneSource website or call <a href="tel:+1800-342-9647">1-800-342-9647</a> anytime, day or night.
 
-<b>[The Psychological Health Resource Center](http://pdhealth.mil/)</b><br>
+<strong>[The Psychological Health Resource Center](http://pdhealth.mil/)</strong><br>
 The center works to improve the lives of Veterans, Servicemembers, and their families by advancing excellence in psychological health care, readiness, and prevention.
 
 </div>
@@ -292,20 +292,20 @@ The center works to improve the lives of Veterans, Servicemembers, and their fam
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="resources-suicide">National Suicide Prevention and Substance Use Resources</button>
 <div id="resources-suicide" class="usa-accordion-content">
 
-<b>[The National Suicide Prevention Lifeline](https://suicidepreventionlifeline.org/)</b><br>
+<strong>[The National Suicide Prevention Lifeline](https://suicidepreventionlifeline.org/)</strong><br>
 This 24/7, 365-day-a-year emergency mental health hotline offers support for people experiencing a mental health crisis.<br>
 
-<b>To reach the hotline:</b>
+<strong>To reach the hotline:</strong>
 - [Start an online chat](https://suicidepreventionlifeline.org/chat/).
 - Or call 1-800-273-TALK (8255) (<a href="tel:+1800-662-4357">1-800-662-4357</a>)
 
-<b>[The American Foundation for Suicide Prevention](https://afsp.org/)</b><br>
+<strong>[The American Foundation for Suicide Prevention](https://afsp.org/)</strong><br>
 The foundation provides mental health resources for people struggling with thoughts of suicide. They also offer supportive educational tools for concerned family, friends and peers.
 
-<b>[The Substance Abuse and Mental Health Services Administration (SAMHSA)](https://www.samhsa.gov/)</b><br>
+<strong>[The Substance Abuse and Mental Health Services Administration (SAMHSA)](https://www.samhsa.gov/)</strong><br>
 SAMHSA offers free, confidential help with treatment referral and information services for individuals and families facing mental health and/or substance use disorders. Support is available 24/7, 365-days-a-year, in both English and Spanish.<br>
 
-<b>To reach SAMHSA's National Helpline:</b>
+<strong>To reach SAMHSA's National Helpline:</strong>
 - Call 1-800-662-HELP (<a href="tel:+1800-662-4357">1-800-662-4357</a>)
 - [Learn more about the helpline](https://www.samhsa.gov/find-help/national-helpline).
 
@@ -315,13 +315,13 @@ SAMHSA offers free, confidential help with treatment referral and information se
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="resources-community">Community Mental Health Resources</button>
 <div id="resources-community" class="usa-accordion-content">
 
-<b>[The National Alliance on Mental Illness (NAMI)](https://www.nami.org/local/)</b><br>
+<strong>[The National Alliance on Mental Illness (NAMI)](https://www.nami.org/local/)</strong><br>
 NAMI builds better lives for millions of Americans affected by mental illness by providing education programs for families and individuals living with mental health problems.
 
-<b>[The Jed Foundation](https://www.jedfoundation.org/)</b><br>
+<strong>[The Jed Foundation](https://www.jedfoundation.org/)</strong><br>
 The foundation works closely with teenagers and young adults who may be experiencing mental stress or may be at risk for suicide during times of change.
 
-<b>[Mental Health America](http://www.mentalhealthamerica.net/)</b><br>
+<strong>[Mental Health America](http://www.mentalhealthamerica.net/)</strong><br>
 This organization advocates for policies that promote mental health and the rights of people living with mental health problems. They also provide education and connections to mental health resources.
 
 </div>

--- a/pages/health-care/how-to-apply.md
+++ b/pages/health-care/how-to-apply.md
@@ -63,15 +63,15 @@ Find out how to apply for VA health care benefits as a Veteran or service member
       <a href="https://www.va.gov/vaforms/medical/pdf/1010EZ-fillable.pdf">Obtenga la Forma VA 10-10EZ</a>.<br>
       Usted o alguien con poder legal para representarlo tiene que firmar la forma, e incluir la fecha en que fué firmada.<br>
       <ul>
-        <li><b>Si esta usando un poder legal</b>, tendra que incluir una copia de la forma con su solicitud.</li>
-        <li><b>Si firma con una X</b>, 2 personas que usted conoce tienen que tambien firmar acertando que lo vieron firmar la forma.</li>
+        <li><strong>Si esta usando un poder legal</strong>, tendra que incluir una copia de la forma con su solicitud.</li>
+        <li><strong>Si firma con una X</strong>, 2 personas que usted conoce tienen que tambien firmar acertando que lo vieron firmar la forma.</li>
       </ul>
-      <b>Puede mandar su solicitud por correo a esta dirección:</b><br>
+      <strong>Puede mandar su solicitud por correo a esta dirección:</strong><br>
       <p class="va-address-block">
         Health Eligibility Center<br>
         2957 Clairmont Rd., Suite 200<br>
         Atlanta, GA 30329</p>
-      <b>Para llenar su solicitude en persona</b>, encuetre el Centro Médico de Veteranos mas cercano en esta liga:<br>
+      <strong>Para llenar su solicitude en persona</strong>, encuetre el Centro Médico de Veteranos mas cercano en esta liga:<br>
       <a href="/find-locations/?facilityType=health">Encuentre el Centro o Clínica de Veteranos mas cercano a usted</a>.<br>
       O reciba ayuda por medio del Departmaneto de Veteranos de su estado.<br>
       <a href="https://www.va.gov/statedva.htm">Encuentre el Departamento de Veteranos de su estado</a>.

--- a/pages/health-care/index.md
+++ b/pages/health-care/index.md
@@ -17,19 +17,19 @@ crosslinks:
   - heading: Other VA Benefits and Services
     links:
     - url: "/disability/"
-      title: <b>Disability Compensation (Pay)</b>
+      title: <strong>Disability Compensation (Pay)</strong>
       description: Learn how to file a claim for disability compensation and manage your disability benefits.
     - url: "/life-insurance/"
-      title: <b>Life Insurance</b>
+      title: <strong>Life Insurance</strong>
       description: Explore your life insurance options and find out how to apply as a Servicemember, Veteran, or family member.
     - url: "/pension/aid-attendance-housebound/"
-      title: <b>Aid and Attendance Benefits and Housebound Allowance</b>
+      title: <strong>Aid and Attendance Benefits and Housebound Allowance</strong>
       description: Find out if you can get increased pension pay as a Veteran or surviving spouse who has disabilities.
     - url: "/burials-memorials/"
-      title: <b>Burial Benefits and Memorial Items</b>
+      title: <strong>Burial Benefits and Memorial Items</strong>
       description: Learn about Veterans burial benefits, how to plan a burial service, and how to get compensation as a survivor.
     - url: "/education/"
-      title: <b>Education and Training</b>
+      title: <strong>Education and Training</strong>
       description: Apply for and manage GI Bill and other education benefits to help pay for college and training programs.
 social:
   - heading: Ask Questions

--- a/pages/health-care/order-hearing-aid-batteries-prosthetic-socks.md
+++ b/pages/health-care/order-hearing-aid-batteries-prosthetic-socks.md
@@ -21,7 +21,7 @@ Find out if you may be eligible to order free hearing aid batteries or prostheti
 <div class="va-sign-in-alert usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">You’ll need to sign in to eBenefits to order hearing aid batteries or prosthetic socks online.</h4><br>
-  <p class="usa-alert-text">To use this feature, you'll need a Premium <b>DS Logon</b> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <b>DS Logon</b> account to Premium.<br>
+  <p class="usa-alert-text">To use this feature, you'll need a Premium <strong>DS Logon</strong> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <strong>DS Logon</strong> account to Premium.<br>
       <a class="usa-button-primary" target="_blank" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=hearing-aid-batteries-and-prosthetic-socks">Go to eBenefits to Order Items Online</a>
     </p>
   </div>

--- a/pages/health-care/refill-track-prescriptions/index.md
+++ b/pages/health-care/refill-track-prescriptions/index.md
@@ -88,7 +88,7 @@ Click on the link you want, and you'll get instructions on the next page to get 
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 
-<b>You can refill and track most of your VA prescriptions, including:</b>
+<strong>You can refill and track most of your VA prescriptions, including:</strong>
 - VA medicines that were refilled or renewed
 - Wound care supplies
 - Diabetic supplies

--- a/pages/health-care/schedule-view-va-appointments.md
+++ b/pages/health-care/schedule-view-va-appointments.md
@@ -34,7 +34,7 @@ With our VA Appointments tools, you can schedule some VA health care appointment
 
 </div>
 
-<p><b>Please note:</b> The fastest way to make all your VA appointments is usually to call the VA health facility where you want to receive care. If you can’t keep an existing appointment, please contact the facility as soon as possible to reschedule or cancel.<br>
+<p><strong>Please note:</strong> The fastest way to make all your VA appointments is usually to call the VA health facility where you want to receive care. If you can’t keep an existing appointment, please contact the facility as soon as possible to reschedule or cancel.<br>
 <a href="/find-locations/">Find your VA health facility’s phone number</a>.</p>
 
 <div class="usa-alert usa-alert-warning">
@@ -80,7 +80,7 @@ With our VA Appointments tools, you can schedule some VA health care appointment
 
 VA Appointments tools offer a secure, web-based way to schedule, view, and organize your VA appointments online.
 
-<b>You can use these tools to:</b>
+<strong>You can use these tools to:</strong>
 
 <ul>
   <li>Schedule some of your VA medical appointments online</li>
@@ -105,19 +105,19 @@ VA Appointments tools offer a secure, web-based way to schedule, view, and organ
 
 You can use these tools if you meet all of the requirements listed below.
 
-<b>All of these must be true. You:</b>
+<strong>All of these must be true. You:</strong>
 <ul>
-  <li>Are enrolled in VA health care, <b>and</b></li>
-  <li>Are scheduling your appointment with a VA health facility that uses online scheduling, <b>and</b></li>
+  <li>Are enrolled in VA health care, <strong>and</strong></li>
+  <li>Are scheduling your appointment with a VA health facility that uses online scheduling, <strong>and</strong></li>
   <li>Have had an appointment at that VA health facility within the last 2 years</li>
 </ul>
 <a href="/health-care/how-to-apply/">Find out how to apply for VA health care</a>.
 
-<b>And, you must have one of these free accounts:</b>
+<strong>And, you must have one of these free accounts:</strong>
 <ul>
-  <li>A Premium <b>My HealtheVet</b> account, <b>or</b></li>
-  <li>A Premium <b>DS Logon</b> account (used for eBenefits and milConnect), <b>or</b></li>
-  <li>A verified <b>ID.me</b> account that you can create here on VA.gov</li>
+  <li>A Premium <strong>My HealtheVet</strong> account, <strong>or</strong></li>
+  <li>A Premium <strong>DS Logon</strong> account (used for eBenefits and milConnect), <strong>or</strong></li>
+  <li>A verified <strong>ID.me</strong> account that you can create here on VA.gov</li>
 </ul>
 
 <a href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types">Learn about the 3 different My HealtheVet account types</a>.
@@ -148,7 +148,7 @@ You can check our list of VA facilities that are currently using the online sche
 
 This will depend on the VA health facility where you’re receiving care.
 
-<b>You may be able to schedule outpatient appointments for:</b>
+<strong>You may be able to schedule outpatient appointments for:</strong>
 <ul>
   <li>Primary care</li>
   <li>Mental health</li>


### PR DESCRIPTION
## Page to edit
A number of pages, but there will be no visible difference to any of them. 

## Origin of request (internal/stakeholder/user feedback)
Drupal CMS as currently configured doesn't support `<b>`, partly because  

> According to the HTML 5 specification, the `<b>` tag should be used as a LAST resort when no other tag is more appropriate. The HTML 5 specification states that headings should be denoted with the `<h1>` to `<h6>` tags, emphasized text should be denoted with the `<em>` tag, important text should be denoted with the `<strong>` tag, and marked/highlighted text should use the `<mark>` tag.

We could allow it to support `<b>`, but it really shouldn't, since editors won't be able to use it in the future with WYSIWYG editor. 

## Description of what's needed (edits/link changes/additions)

Change all `<b>` tags to `<strong>` tags.

## For code review. 

Read diff closely to make sure all `<`, `>` and `/` remain the same. The only changes should be `b` and `strong`