### PR TITLE
[Analytics] Add Homeless Expander GA event

### DIFF
--- a/pages/careers-employment/index.md
+++ b/pages/careers-employment/index.md
@@ -210,7 +210,7 @@ We can support you in all stages of your job search—from returning to work wit
 
 <div class="usa-alert usa-alert-warning">
   <div class="usa-alert-body">
-    <h4 class="usa-alert-heading">How do I get help if I'm homeless or at risk of becoming homeless?<br><a id="crisis-expander-link">We may be able to help</a>.</h4>
+    <h4 class="usa-alert-heading">How do I get help if I'm homeless or at risk of becoming homeless?<br><a id="crisis-expander-link" onClick="recordEvent({event: 'nav-crisis-homelessness-expander'});">We may be able to help</a>.</h4>
     <div id="crisis-expander-content" class="expander-content expander-content-closed">
       <div class="expander-content-inner usa-alert-text">
         <p>We offer many programs and services that may help—including free health care and, in some cases, free limited dental care. We can also help you connect with resources in your community, like homeless shelters or faith-based organizations.</p>

--- a/pages/health-care/index.md
+++ b/pages/health-care/index.md
@@ -190,7 +190,7 @@ With VA health care, you’re covered for regular checkups with your primary car
 
 <div class="usa-alert usa-alert-warning">
   <div class="usa-alert-body">
-    <h4 class="usa-alert-heading">How do I get help if I'm homeless or at risk of becoming homeless?<br><a id="crisis-expander-link">We may be able to help</a>.</h4>
+    <h4 class="usa-alert-heading">How do I get help if I'm homeless or at risk of becoming homeless?<br><a id="crisis-expander-link" onClick="recordEvent({event: 'nav-crisis-homelessness-expander'});">We may be able to help</a>.</h4>
     <div id="crisis-expander-content" class="expander-content expander-content-closed">
       <div class="expander-content-inner usa-alert-text">
 

--- a/pages/housing-assistance/index.md
+++ b/pages/housing-assistance/index.md
@@ -173,7 +173,7 @@ VA housing assistance can help Servicemembers, Veterans, and their surviving spo
 </ul>
 <div class="usa-alert usa-alert-warning">
   <div class="usa-alert-body">
-    <h4 class="usa-alert-heading">How do I get help if I'm homeless or at risk of becoming homeless?<br><a id="crisis-expander-link">We may be able to help</a>.</h4>
+    <h4 class="usa-alert-heading">How do I get help if I'm homeless or at risk of becoming homeless?<br><a id="crisis-expander-link" onClick="recordEvent({event: 'nav-crisis-homelessness-expander'});">We may be able to help</a>.</h4>
     <div id="crisis-expander-content" class="expander-content expander-content-closed">
       <div class="expander-content-inner usa-alert-text">
 


### PR DESCRIPTION
## Page to edit
url: 
```
/housing-assistance/
/careers-employment/
/health-care/
```
## Origin of request (internal/stakeholder/user feedback)
internal from @nedierecel
## Description of what's needed (edits/link changes/additions)
This purpose of this PR is to add `'event': 'nav-crisis-homelessness-expander'` on the "We may be able to help" link in the homeless alert box on the urls above.

![Screen Shot 2019-03-25 at 11 17 09 AM](https://user-images.githubusercontent.com/11021491/54931639-c6256300-4eef-11e9-801e-da7f4f5e5ec4.png)

