### PR TITLE
Change Servicemember to service member. (#376)

### DIFF
--- a/pages/burials-memorials/bereavement-counseling.md
+++ b/pages/burials-memorials/bereavement-counseling.md
@@ -17,7 +17,7 @@ relatedlinks:
       description: Find out if you can get tax-free monetary benefits.
     - url: /burials-memorials/plan-a-burial/
       title: Burial Planning
-      description: Find out the steps you’ll need to take to arrange for a Servicemember, Veteran, or eligible family member’s burial.
+      description: Find out the steps you’ll need to take to arrange for a service member, Veteran, or eligible family member’s burial.
     - url: /burials-memorials/what-to-expect-at-military-funeral/
       title: What to Expect at a Memorial Service
       description: Find out what will happen to help you prepare for this day.
@@ -31,7 +31,7 @@ aliases:
 
 <div class="va-introtext">
 
-If you’re the surviving spouse, child, or parent of a Servicemember who died while serving their country, you may qualify for bereavement counseling through VA. Bereavement counseling (also sometimes called "grief counseling") provides assistance and support for people going through emotional and psychological stress after the death of a loved one.
+If you’re the surviving spouse, child, or parent of a service member who died while serving their country, you may qualify for bereavement counseling through VA. Bereavement counseling (also sometimes called "grief counseling") provides assistance and support for people going through emotional and psychological stress after the death of a loved one.
 
 </div>
 
@@ -42,7 +42,7 @@ If you’re the surviving spouse, child, or parent of a Servicemember who died w
 ### Can I get bereavement (or grief) counseling?
 
 **You may qualify for bereavement counseling if you’re the surviving spouse, child, or parent of:**
-- A Servicemember who died while serving their country
+- A service member who died while serving their country
 - A Reservist who died while on active duty
 - A National Guard Soldier who died while on active duty
 

--- a/pages/burials-memorials/dependency-indemnity-compensation.md
+++ b/pages/burials-memorials/dependency-indemnity-compensation.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Compensation for Surviving Spouse and Dependents (VA DIC)
 display_title: Survivor and Dependent Compensation (DIC)
-description: Find out how to apply for VA Dependent and Indemnity Compensation (VA DIC). These VA benefits for spouses, children, and parents of Veterans and Servicemembers who died in the line of duty or from a service-related injury or illness give a tax-free monthly payment to eligible survivors.
+description: Find out how to apply for VA Dependent and Indemnity Compensation (VA DIC). These VA benefits for spouses, children, and parents of Veterans and service members who died in the line of duty or from a service-related injury or illness give a tax-free monthly payment to eligible survivors.
 order: 5
 collection: burials
 spoke: Get Benefits
@@ -13,7 +13,7 @@ aliases:
 
 <div class="va-introtext">
 
-If you’re the surviving spouse, child, or parent of a Servicemember who died in the line of duty, or the survivor of a Veteran who died from a service-related injury or illness, you may be able to get a tax-free monetary benefit called VA Dependency and Indemnity Compensation (VA DIC). Find out if you can get compensation.
+If you’re the surviving spouse, child, or parent of a service member who died in the line of duty, or the survivor of a Veteran who died from a service-related injury or illness, you may be able to get a tax-free monetary benefit called VA Dependency and Indemnity Compensation (VA DIC). Find out if you can get compensation.
 
 </div>
 
@@ -24,18 +24,18 @@ If you’re the surviving spouse, child, or parent of a Servicemember who died i
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="VA-burials-survivor-spouse">As a surviving spouse</button>
 <div id="VA-burials-survivor-spouse" class="usa-accordion-content">
 
-You may be able to get compensation as a surviving spouse if you meet the requirements listed below. You'll also need to provide evidence with your claim showing that one of the descriptions below is true for the Veteran or Servicemember. Evidence may include documents like military service records, doctor's reports, and medical test results.
+You may be able to get compensation as a surviving spouse if you meet the requirements listed below. You'll also need to provide evidence with your claim showing that one of the descriptions below is true for the Veteran or service member. Evidence may include documents like military service records, doctor's reports, and medical test results.
 
 **One of these must be true. You:**
-- Married the Veteran or Servicemember before January 1, 1957, **or**
-- Married the Veteran or Servicemember within 15 years of their discharge from the period of military service during which the qualifying illness or injury started or got worse, **or**
-- Were married to the Veteran or Servicemember for at least 1 year, **or**
-- Had a child with the Veteran or Servicemember, aren’t currently remarried, and either lived with the Veteran or Servicemember without a break until their death or, if separated, weren’t at fault for the separation
+- Married the Veteran or service member before January 1, 1957, **or**
+- Married the Veteran or service member within 15 years of their discharge from the period of military service during which the qualifying illness or injury started or got worse, **or**
+- Were married to the Veteran or service member for at least 1 year, **or**
+- Had a child with the Veteran or service member, aren’t currently remarried, and either lived with the Veteran or service member without a break until their death or, if separated, weren’t at fault for the separation
 
 **Note:** If you remarried on or after December 16, 2003, and you were 57 years of age or older at the time you remarried, you can still continue to receive compensation.
 
-**You'll also need to provide evidence showing that one of these descriptions is true for the Veteran or Servicemember:**
-- The Servicemember died while on active duty, active duty for training, or inactive-duty training, **or**
+**You'll also need to provide evidence showing that one of these descriptions is true for the Veteran or service member:**
+- The service member died while on active duty, active duty for training, or inactive-duty training, **or**
 - The Veteran died from a service-connected illness or injury, **or**
 - The Veteran didn’t die from a service-connected illness or injury, but was eligible to receive VA compensation for a service-connected disability rated as totally disabling for a certain period of time
 
@@ -52,17 +52,17 @@ You may be able to get compensation as a surviving spouse if you meet the requir
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="VA-burials-survivor-child">As a surviving child</button>
 <div id="VA-burials-survivor-child" class="usa-accordion-content">
 
-You may be able to get compensation as a surviving child if you meet the requirements listed below. You'll also need to provide evidence with your claim showing that one of the descriptions below is true for the Veteran or Servicemember. Evidence may include documents like military service records, doctor's reports, and medical test results.
+You may be able to get compensation as a surviving child if you meet the requirements listed below. You'll also need to provide evidence with your claim showing that one of the descriptions below is true for the Veteran or service member. Evidence may include documents like military service records, doctor's reports, and medical test results.
 
 **All of these must be true. You:**
 - Aren’t married, **and**
 - Aren’t included on the surviving spouse’s compensation, **and**
 - Are under the age of 18 (or under the age of 23 if attending school)
 
-**Note:** If you were adopted out of the Veteran's or Servicemember's family, but meet all other eligibility criteria, you still qualify for compensation.
+**Note:** If you were adopted out of the Veteran's or service member's family, but meet all other eligibility criteria, you still qualify for compensation.
 
-**You'll also need to provide evidence that one of these descriptions is true for the Veteran or Servicemember:**
-- The Servicemember died while on active duty, active duty for training, or inactive-duty training, **or**
+**You'll also need to provide evidence that one of these descriptions is true for the Veteran or service member:**
+- The service member died while on active duty, active duty for training, or inactive-duty training, **or**
 - The Veteran died from a service-connected illness or injury, **or**
 - The Veteran didn’t die from a service-connected illness or injury, but was eligible to receive VA compensation for a service-connected disability that was rated as totally disabling for a certain period of time
 
@@ -79,18 +79,18 @@ You may be able to get compensation as a surviving child if you meet the require
 <button class="usa-button-unstyled usa-accordion-button" aria-controls="VA-burials-survivor-parent">As a surviving parent</button>
 <div id="VA-burials-survivor-parent" class="usa-accordion-content">
 
-You may be able to get compensation as a surviving parent if both of the descriptions below are true for you. You'll also need to provide evidence with your claim showing that one of the descriptions below is true for the Veteran or Servicemember. Evidence may include documents like military service records, doctor's reports, and medical test results.
+You may be able to get compensation as a surviving parent if both of the descriptions below are true for you. You'll also need to provide evidence with your claim showing that one of the descriptions below is true for the Veteran or service member. Evidence may include documents like military service records, doctor's reports, and medical test results.
 
 **Both of these must be true:**
-- You're the biological, adoptive, or foster parent of the Veteran or Servicemember, **and**
+- You're the biological, adoptive, or foster parent of the Veteran or service member, **and**
 - Your income is below a certain amount <br>
 [View the parents DIC rate table]( https://benefits.va.gov/Pension/current_rates_Parents_DIC_pen.asp).
 
-**Note:** We define a foster parent as someone who served in the role of a parent to the Veteran or Servicemember before their last entry into active service.
+**Note:** We define a foster parent as someone who served in the role of a parent to the Veteran or service member before their last entry into active service.
 
-**You'll also need to provide evidence that one of these descriptions is true for the Veteran or Servicemember:**
-- The Servicemember died from an injury or illness while on active duty or in the line of duty while on active duty for training, **or**
-- The Servicemember died from an injury or certain illnesses in the line of duty while on inactive training, **or**
+**You'll also need to provide evidence that one of these descriptions is true for the Veteran or service member:**
+- The service member died from an injury or illness while on active duty or in the line of duty while on active duty for training, **or**
+- The service member died from an injury or certain illnesses in the line of duty while on inactive training, **or**
 - The Veteran died from a service-connected illness or injury
 
   </div>
@@ -107,7 +107,7 @@ Tax-free monetary benefits
 
 First you’ll need to fill out an application for benefits. The application you fill out will depend on your survivor status.
 
-**If you're the surviving spouse or child of a Servicemember who died while on active duty,** your Military Casualty Assistance Officer will help you to complete an Application for DIC, Death Pension, and/or Accrued Benefits by a Surviving Spouse or Child (VA Form 21P-534a). The officer will help you mail the form to the correct VA regional benefit office.<br>
+**If you're the surviving spouse or child of a service member who died while on active duty,** your Military Casualty Assistance Officer will help you to complete an Application for DIC, Death Pension, and/or Accrued Benefits by a Surviving Spouse or Child (VA Form 21P-534a). The officer will help you mail the form to the correct VA regional benefit office.<br>
 [Download VA Form 21P-534a](https://www.vba.va.gov/pubs/forms/VBA-21P-534a-ARE.pdf).
 
 **If you’re the surviving spouse or child of a Veteran,** fill out an Application for DIC, Death Pension, and/or Accrued Benefits (VA Form 21P-534EZ). <br>

--- a/pages/burials-memorials/eligibility.md
+++ b/pages/burials-memorials/eligibility.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Eligibility for Burial in a VA National Cemetery
 display_title: Eligibility
-description: Find out if you or a loved one qualify for burial in a VA national cemetery and for other burial honors. Review VA burial benefits eligibility requirements for Veterans, Servicemembers, spouses, and dependents.
+description: Find out if you or a loved one qualify for burial in a VA national cemetery and for other burial honors. Review VA burial benefits eligibility requirements for Veterans, service members, spouses, and dependents.
 collection: burials
 children: burialsEligibility
 spoke: Get Benefits
@@ -15,7 +15,7 @@ aliases:
 
 <div class="va-introtext">
 
-Servicemembers, Veterans, and family members may qualify for burial in a VA national cemetery and for other burial honors, like a headstone, marker, medallion, burial flag, and Presidential Memorial Certificate. Some family members may also qualify for money to pay for burial costs. Find out if you can get these benefits.
+Service members, Veterans, and family members may qualify for burial in a VA national cemetery and for other burial honors, like a headstone, marker, medallion, burial flag, and Presidential Memorial Certificate. Some family members may also qualify for money to pay for burial costs. Find out if you can get these benefits.
 
 </div>
 
@@ -23,12 +23,12 @@ Servicemembers, Veterans, and family members may qualify for burial in a VA nati
 
 ### Who can be buried in a VA national cemetery and receive other burial benefits?
 
-Veterans, Servicemembers, spouses, and dependents may qualify for burial in a VA national cemetery, as well as other benefits, if they meet one of the requirements listed below.
+Veterans, service members, spouses, and dependents may qualify for burial in a VA national cemetery, as well as other benefits, if they meet one of the requirements listed below.
 
 **One of these must be true. The person qualifying for burial benefits is:**
 
 - A Veteran who didn't receive a dishonorable discharge, **or**
-- A Servicemember who died while on active duty, active duty for training, or inactive duty for training, **or**
+- A service member who died while on active duty, active duty for training, or inactive duty for training, **or**
 - The spouse or dependent child of a Veteran, even if the Veteran died first, **or**
 - In some cases, the adult dependent child of a Veteran (if they aren't married)
 
@@ -50,7 +50,7 @@ If you've received one of these discharge statuses, you may not be eligible for 
 
 ## What do burial benefits include?
 
-If you qualify for burial in a VA national cemetery, you'll receive burial benefits at no cost to your family. 
+If you qualify for burial in a VA national cemetery, you'll receive burial benefits at no cost to your family.
 
 **Burial benefits include:**
 - Opening and closing of the grave
@@ -58,7 +58,7 @@ If you qualify for burial in a VA national cemetery, you'll receive burial benef
 - A headstone or marker provided by the government
 - Perpetual (ongoing) care of the gravesite
 
-At the time of need, the person planning the burial can also request other honors and memorial items. 
+At the time of need, the person planning the burial can also request other honors and memorial items.
 
 **Honors and memorial items may include a:**
 - [Burial flag to drape over the casket (or coffin) or place with the urn](/burials-memorials/memorial-items/burial-flags/)
@@ -68,9 +68,9 @@ At the time of need, the person planning the burial can also request other honor
 [Learn about the burial planning process](/burials-memorials/plan-a-burial/). <br />
 [Learn about memorial items](/burials-memorials/memorial-items/).
 
-## If I'm the survivor of a Veteran or Servicemember, what other benefits can I get?
+## If I'm the survivor of a Veteran or service member, what other benefits can I get?
 
-We give the surviving spouse, children, and parents of Veterans and Servicemembers a range of benefits. These may include tax-free monetary benefits (called Dependency and Indemnity Compensation) and help paying for the funeral service (called a burial allowance).<br>
+We give the surviving spouse, children, and parents of Veterans and service members a range of benefits. These may include tax-free monetary benefits (called Dependency and Indemnity Compensation) and help paying for the funeral service (called a burial allowance).<br>
 [See if you're eligible for Dependency and Indemnity Compensation (DIC)](/burials-memorials/dependency-indemnity-compensation/). <br>
 [Find out how to apply for a burial allowance](/burials-memorials/veterans-burial-allowance/).
 

--- a/pages/burials-memorials/index.md
+++ b/pages/burials-memorials/index.md
@@ -106,7 +106,7 @@ hublinks:
     - url: "/burials-memorials/bereavement-counseling/"
       label: Bereavement Counseling
       description: See if you qualify for grief counseling and transition support after
-        the loss of an active-duty Servicemember, Reservist, or National Guard Soldier.
+        the loss of an active-duty service member, Reservist, or National Guard Soldier.
       external: false
   - id: manage
     title: Plan a Burial
@@ -177,7 +177,7 @@ hublinks:
 ---
 
 <p class="va-introtext">
-VA burial benefits can help Servicemembers, Veterans, and their family members plan and pay for a burial or memorial service in a VA national cemetery. Family members can also order memorial items to honor the service of a Veteran. Find out how to apply for the burial benefits you've earned, and how to plan for a burial in advance or at time of need.</p>
+VA burial benefits can help service members, Veterans, and their family members plan and pay for a burial or memorial service in a VA national cemetery. Family members can also order memorial items to honor the service of a Veteran. Find out how to apply for the burial benefits you've earned, and how to plan for a burial in advance or at time of need.</p>
 
 <h3>On This Page</h3>
 

--- a/pages/burials-memorials/memorial-items/headstones-markers-medallions.md
+++ b/pages/burials-memorials/memorial-items/headstones-markers-medallions.md
@@ -105,6 +105,6 @@ You can apply for one of these memorial items if you're representing the Veteran
 
 We provide memorial headstones and markers for qualified Veterans when their remains are missing, not identified, donated to science, buried at sea, or scattered.
 
-For Veterans, dependents, and Servicemembers who qualify for a memorial headstone or marker, the words engraved on the memorial item must begin, “IN MEMORY OF,” and the headstone or marker must be placed in a national cemetery, state Veterans cemetery, or military base cemetery.
+For Veterans, dependents, and service members who qualify for a memorial headstone or marker, the words engraved on the memorial item must begin, “IN MEMORY OF,” and the headstone or marker must be placed in a national cemetery, state Veterans cemetery, or military base cemetery.
 
 Get help applying for a headstone, marker, niche cover, or medallion by calling <a href="tel:+8006976947">1-800-697-6947</a>.

--- a/pages/burials-memorials/plan-a-burial.md
+++ b/pages/burials-memorials/plan-a-burial.md
@@ -49,30 +49,30 @@ To start, you may want to choose a funeral director to help you plan the burial.
 
 **You'll need:**
 
- - The DD214 or other discharge documents of the Veteran or Servicemember whose military service will be used to determine eligibility for burial in a VA national cemetery. If you can't find these documents, please ask for our help to get them. <br>
+ - The DD214 or other discharge documents of the Veteran or service member whose military service will be used to determine eligibility for burial in a VA national cemetery. If you can't find these documents, please ask for our help to get them. <br>
  [Find out which discharge documents we accept along with your application](https://www.cem.va.gov/CEM/hmm/discharge_documents.asp).
 
-**You'll also need the information listed below about the Veteran, Servicemember, or dependent family member:**
+**You'll also need the information listed below about the Veteran, service member, or dependent family member:**
 
  - Name
  - Gender
  - Social Security number or Military Service number (Veteran ID)
  - Date of birth
- - Relationship to the Servicemember or Veteran whose military service will be used to decide eligibility
+ - Relationship to the service member or Veteran whose military service will be used to decide eligibility
  - Marital status
  - Date of death (and zip code and county at the time of death)
 
-**You'll need information about the next-of-kin (the closest living relative of the Veteran, Servicemember, or dependent family member), including the person's:**
+**You'll need information about the next-of-kin (the closest living relative of the Veteran, service member, or dependent family member), including the person's:**
 
    - Name
-   - Relationship to the Veteran, Servicemember, or dependent family member
+   - Relationship to the Veteran, service member, or dependent family member
    - Social Security number
    - Phone number
    - Address
 
 **You may also need more information in certain cases:**
 
-- **If the person was married**, you'll also need the surviving spouse’s status as Veteran, Servicemember, or family member.
+- **If the person was married**, you'll also need the surviving spouse’s status as Veteran, service member, or family member.
 - **If the person has any children with disabilities**, you'll need the status and detailed information for any disabled children who may be buried in the future in a national cemetery.
 - **If the person's spouse passed away previously and was buried in a VA national cemetery**, you'll need the full name of the spouse as well as the cemetery section and site number where they're buried.
 

--- a/pages/burials-memorials/pre-need-eligibility.md
+++ b/pages/burials-memorials/pre-need-eligibility.md
@@ -38,10 +38,10 @@ You can apply to find out in advance if you can be buried in a VA national cemet
 <li class="process-step list-one">
 
 #### Make sure one of these describes you:
-- A Servicemember on active duty, **or**
+- A service member on active duty, **or**
 - A Veteran who didn't receive a dishonorable discharge when you separated from the military, **or**
-- The spouse or dependent child of a Servicemember or Veteran, even if the Servicemember or Veteran has already passed away, **or**
-- In some cases, the adult dependent child of a Servicemember or Veteran (if you aren’t married)
+- The spouse or dependent child of a service member or Veteran, even if the service member or Veteran has already passed away, **or**
+- In some cases, the adult dependent child of a service member or Veteran (if you aren’t married)
 
 </li>
 
@@ -82,7 +82,7 @@ If both you and your spouse are applying, you’ll each need to fill out your ow
 
 ### What documents and information do I need to apply?
 
-We base our decision of whether or not you qualify for burial in a VA national cemetery on your service history—or the service history of the Veteran or Servicemember who's sponsoring your application for burial as a spouse, surviving spouse, or unmarried adult child.
+We base our decision of whether or not you qualify for burial in a VA national cemetery on your service history—or the service history of the Veteran or service member who's sponsoring your application for burial as a spouse, surviving spouse, or unmarried adult child.
 
 **To apply, you’ll need your (or your sponsor's):**
 
@@ -97,7 +97,7 @@ We base our decision of whether or not you qualify for burial in a VA national c
 
 - **If you’re applying as a spouse, surviving spouse, or unmarried adult child,** you’ll also need your personal information, including your Social Security number.
 - **If you're applying on behalf of someone else,** you'll also need supporting documents showing you have the authority to apply for that person.
-- **If you're applying for an unmarried adult child of a Veteran or Servicemember,** you'll also need to provide supporting documents with information about the child's disability.
+- **If you're applying for an unmarried adult child of a Veteran or service member,** you'll also need to provide supporting documents with information about the child's disability.
 
 </div>
 

--- a/pages/burials-memorials/what-to-expect-at-military-funeral.md
+++ b/pages/burials-memorials/what-to-expect-at-military-funeral.md
@@ -11,11 +11,11 @@ spoke: More Resources
 
 <div class="va-introtext">
 
-We carry out memorial services at national cemeteries with dignity and respect. Find out what happens at a military funeral for a Veteran or Servicemember.
+We carry out memorial services at national cemeteries with dignity and respect. Find out what happens at a military funeral for a Veteran or service member.
 
 </div>
 
-## What happens during a military funeral for a Veteran or Servicemember?
+## What happens during a military funeral for a Veteran or service member?
 
 There may be a brief ceremony, including any readings or military honors, led by someone of the family's choice. This ceremony will take place at a special area called a committal shelter (not at the gravesite). A cemetery official will be there to help guide guests and family members.
 
@@ -25,7 +25,7 @@ The family may also choose to have military funeral honors performed during the 
 - The playing of “Taps”
 - A rifle detail
 - A color guard
-- Uniformed Servicemembers who present the burial flag
+- Uniformed service members who present the burial flag
 
 **Note:** If you requested a headstone, marker, or medallion, we’ll arrange for it to be delivered within 60 days. <br>
 [Learn about Veterans headstones, markers, and medallions](/burials-memorials/memorial-items/headstones-markers-medallions/).

--- a/pages/careers-employment/careerscope-skills-assessment.md
+++ b/pages/careers-employment/careerscope-skills-assessment.md
@@ -19,7 +19,7 @@ In addition to getting career counseling, you may be able to use CareerScope, a 
 
 ## Can I use CareerScope?
 
-You can use CareerScope if you're a Veteran, Servicemember, or dependent who qualifies for—or is already getting—VA education benefits. [Get started with CareerScope](https://va.careerscope.net/gibill).
+You can use CareerScope if you're a Veteran, service member, or dependent who qualifies for—or is already getting—VA education benefits. [Get started with CareerScope](https://va.careerscope.net/gibill).
 
 The Report Interpretation guide helps you understand your CareerScope results. [Use the guide](https://www.benefits.va.gov/gibill/docs/job_aids/CareerScope_Report_Interpretation.pdf).
 

--- a/pages/careers-employment/dependent-benefits.md
+++ b/pages/careers-employment/dependent-benefits.md
@@ -23,7 +23,7 @@ aliases:
 
 <div class="va-introtext">
 
-Find out if you're eligible and how to apply to get career and educational counseling through VR&E as the dependent family member of a Servicemember or Veteran with a service-connected disability.
+Find out if you're eligible and how to apply to get career and educational counseling through VR&E as the dependent family member of a service member or Veteran with a service-connected disability.
 
 </div>
 
@@ -101,6 +101,6 @@ You can apply online right now.
 
 <a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
 
-**Note:** If the Servicemember or Veteran in your family isn’t yet using VR&E benefits and services, they may also apply online through eBenefits.
+**Note:** If the service member or Veteran in your family isn’t yet using VR&E benefits and services, they may also apply online through eBenefits.
 
 <span id="dependents-services">

--- a/pages/careers-employment/family-resources.md
+++ b/pages/careers-employment/family-resources.md
@@ -26,9 +26,9 @@ Through the Department of Defense’s [Spouse Education Career Opportunities](ht
 ### Are you eligible for SECO services?
 Yes, if:
 
-- You are the spouse of an active-duty, National Guard, or Reserve Servicemember in the Army, Marine Corps, Navy, or Air Force.
-- You are the spouse of a Servicemember who has been separated from active duty, National Guard, or Reserves for less than 180 days.
-- You are the surviving spouse of a Servicemember who died while on active duty.
+- You are the spouse of an active-duty, National Guard, or Reserve service member in the Army, Marine Corps, Navy, or Air Force.
+- You are the spouse of a service member who has been separated from active duty, National Guard, or Reserves for less than 180 days.
+- You are the surviving spouse of a service member who died while on active duty.
 </div>
 
 ### Other programs

--- a/pages/careers-employment/index.md
+++ b/pages/careers-employment/index.md
@@ -38,7 +38,7 @@ crosslinks:
       description: Apply for a Certificate of Eligibility for a VA direct or VA-backed home loan to build, buy, improve, or refinance a home.
     - url: /life-insurance/
       title: <b>Life Insurance</b>
-      description: Explore your life insurance options and find out how to apply as a Servicemember, Veteran, or family member.
+      description: Explore your life insurance options and find out how to apply as a service member, Veteran, or family member.
 social:
   - heading: Ask Questions
     subsections:
@@ -97,7 +97,7 @@ hublinks:
     links:
     - url: "/careers-employment/vocational-rehabilitation/programs/"
       label: About Vocational Rehabilitation and Employment (Chapter 31) Programs
-      description: Explore support-and-services program tracks for Veterans and Servicemembers
+      description: Explore support-and-services program tracks for Veterans and service members
         with service-connected disabilities. Our programs can help you learn new skills,
         find a new job, start a new business, get educational counseling, or return
         to your former job.
@@ -125,7 +125,7 @@ hublinks:
     - url: "/careers-employment/dependent-benefits/"
       label: Support for Dependent Family Members
       description: See if you're eligible for educational and vocational counseling
-        as the dependent spouse or child of a Veteran or Servicemember.
+        as the dependent spouse or child of a Veteran or service member.
       external: false
   - id: manage
     title: Manage Your Career
@@ -192,7 +192,7 @@ hublinks:
     - url: "/careers-employment/family-resources/"
       label: Resources for Family Members
       description: Access valuable career resources for spouses and other family members
-        of Veterans and Servicemembers.
+        of Veterans and service members.
       external: false
 ---
 

--- a/pages/careers-employment/veteran-owned-business-support.md
+++ b/pages/careers-employment/veteran-owned-business-support.md
@@ -137,7 +137,7 @@ Yes. The U.S. Small Business Administration (SBA) can provide you with resources
 [Learn about SBA’s Office of Veterans Business Development (OVBD)](https://www.sba.gov/business-guide/grow/veteran-owned-businesses-programs#section-header-0).<br>
 
 Find out about these training programs offered by the Institute for Veterans and Military Families at Syracuse University in partnership with SBA and other organizations:
-- [Boots to Business (for Servicemembers and their spouses)](https://ivmf.syracuse.edu/veteran-and-family-resources/starting-growing-a-business/boots-to-business/).
+- [Boots to Business (for service members and their spouses)](https://ivmf.syracuse.edu/veteran-and-family-resources/starting-growing-a-business/boots-to-business/).
 - [Entrepreneurship Bootcamp for Veterans with Disabilities (for post-9/11 Veterans with service-connected disabilities and their family caregivers)](http://ebv.vets.syr.edu/)
 - [Veteran Women Igniting the Spirit of Entrepreneurship (for women Veterans and female military spouses and partners)](https://ivmf.syracuse.edu/veteran-and-family-resources/starting-growing-a-business/v-wise/)<br>
 

--- a/pages/careers-employment/veteran-resources.md
+++ b/pages/careers-employment/veteran-resources.md
@@ -10,11 +10,11 @@ relatedlinks:
   - heading: More information about VR&E benefits and services
     links:
     - url: /careers-employment/vocational-rehabilitation/programs/
-      title: VR&E Programs for Servicemembers and Veterans
+      title: VR&E Programs for Service Members and Veterans
       description: Explore VR&E support-and-services tracks for help learning new skills, finding a new job, starting a business, getting educational counseling, or returning to your former job.
     - url: /careers-employment/vocational-rehabilitation/how-to-apply/
       title: How to Apply for VR&E
-      description: Find out how to apply for VR&amp;E benefits and services as a Servicemember or Veteran.
+      description: Find out how to apply for VR&amp;E benefits and services as a service member or Veteran.
     - url: /careers-employment/dependent-benefits/
       title: Dependent Family Members
       description: Find out if you're eligible for certain counseling services, training, and education benefits.
@@ -30,10 +30,10 @@ aliases:
 
 **[Operation Pave: Paving Access for Veterans Employment](http://www.pva.org/site/c.ajIRK9NJLcJ2E/b.7750849/k.36C/Operation_PAVE_Paving_Access_for_Veterans_Employment.htm)** can help you find a job and access resources for workplace accommodations if you have a spinal-cord injury. Workplace accommodations are changes or adjustments to a job, work environment, or work process that set you up to do your job despite your disability. Examples of workplace accommodations include special equipment, ramps to make buildings wheelchair accessible, or modified work schedules.
 
-**[Veterans' Employment and Training Service (VETS)](https://www.dol.gov/vets/)** provides you and your family members with employment resources and advice. VETS also offers information on how you can protect your employment rights. 
+**[Veterans' Employment and Training Service (VETS)](https://www.dol.gov/vets/)** provides you and your family members with employment resources and advice. VETS also offers information on how you can protect your employment rights.
 
-**[VA for Vets](https://www.vaforvets.va.gov/)**, the website of the Veteran Employment Services Office's (VESO), can help you find a job when you transition to civilian life. 
+**[VA for Vets](https://www.vaforvets.va.gov/)**, the website of the Veteran Employment Services Office's (VESO), can help you find a job when you transition to civilian life.
 
-**[The National Resource Directory](https://nrd.gov/)** provides links to employment resources across all government agencies. 
+**[The National Resource Directory](https://nrd.gov/)** provides links to employment resources across all government agencies.
 
 **[Veterans Opportunity to Work](https://www.benefits.va.gov/vow/)** connects you with education and training services designed to help you transition to civilian life.  

--- a/pages/careers-employment/vetsuccess-on-campus.md
+++ b/pages/careers-employment/vetsuccess-on-campus.md
@@ -9,11 +9,11 @@ relatedlinks:
   - heading: More information about VR&E benefits and services
     links:
     - url: /careers-employment/vocational-rehabilitation/programs/
-      title: Programs for Servicemembers and Veterans
+      title: Programs for Service Members and Veterans
       description: Explore VR&E support-and-services tracks for help learning new skills, finding a new job, starting a business, getting educational counseling, or returning to your former job.
     - url: /careers-employment/vocational-rehabilitation/how-to-apply/
       title: How to Apply for VR&E
-      description: Find out how to apply for VR&amp;E benefits and services as a Servicemember or Veteran.
+      description: Find out how to apply for VR&amp;E benefits and services as a service member or Veteran.
     - url: /careers-employment/dependent-benefits/
       title: Dependent Family Members
       description: Find out if you're eligible for certain counseling services, training, and education benefits.
@@ -23,11 +23,11 @@ aliases:
 
 <div class="va-introtext">
 
-VetSuccess on Campus (VSOC) supports Veterans, Servicemembers, and some eligible dependents in their transition from military to college life. We have Vocational Rehabilitation Counselors (called VSOC Counselors) at 104 college campuses across the country.
+VetSuccess on Campus (VSOC) supports Veterans, service members, and some eligible dependents in their transition from military to college life. We have Vocational Rehabilitation Counselors (called VSOC Counselors) at 104 college campuses across the country.
 
 </div>
 
-## How our counselors can help you as a Veteran or Servicemember
+## How our counselors can help you as a Veteran or service member
 
 Our counselors can help you with your Veterans’ benefits, which may include VA health services and education benefits. They can also show you how to get referrals for health services and disability accommodations (like help with taking notes or completing writing assignments) in the classroom. <br>
 [Find out if your college has a VSOC Counselor](http://www.benefits.va.gov/vocrehab/vsoc.asp).
@@ -48,5 +48,3 @@ This program is also available to dependents of Veterans who meet at least one o
 - Have had GI Bill benefits transferred from a spouse or parent, **or**
 - [Are eligible for educational assistance under any GI Bill program](/education/about-gi-bill-benefits/)
 <br>
-
-

--- a/pages/careers-employment/vocational-rehabilitation.md
+++ b/pages/careers-employment/vocational-rehabilitation.md
@@ -10,21 +10,21 @@ spoke: Get Benefits
 children: vre
 order: 1
 majorlinks:
-  - heading: For Servicemembers and Veterans with Service-Connected Disabilities
+  - heading: For Service Members and Veterans with Service-Connected Disabilities
     links:
       - url: /careers-employment/vocational-rehabilitation/programs/
-        title: VR&E Programs for Servicemembers and Veterans
+        title: VR&E Programs for Service Members and Veterans
         description: Explore VR&E support-and-services tracks for help learning new skills, finding a new job, starting a business, getting educational counseling, or returning to your former job.
       - url: /careers-employment/vocational-rehabilitation/eligibility/
         title: Eligibility
-        description: Find out if you can get VR&E benefits and services as a Servicemember or Veteran.
+        description: Find out if you can get VR&E benefits and services as a service member or Veteran.
       - url: /careers-employment/vocational-rehabilitation/how-to-apply/
         title: How to Apply
-        description: Find out how to apply for VR&amp;E benefits and services as a Servicemember or Veteran.
+        description: Find out how to apply for VR&amp;E benefits and services as a service member or Veteran.
       - url: /careers-employment/vocational-rehabilitation/ides/
         title: Accessing VR&E through the Integrated Disability Evaluation System (IDES)
         description: If you're wounded, injured, or fall ill while serving and can't perform your duties, find out how you can access VR&E services as soon as possible through IDES.
-  - heading: For Family Members of Servicemembers and Veterans with Service-Connected Disabilities
+  - heading: For Family Members of service members and Veterans with Service-Connected Disabilities
     links:
       - url: /careers-employment/dependent-benefits/
         title: Dependent Family Members

--- a/pages/careers-employment/vocational-rehabilitation/eligibility.md
+++ b/pages/careers-employment/vocational-rehabilitation/eligibility.md
@@ -8,14 +8,14 @@ majorlinks:
   - heading: More information about VR&E benefits and services
     links:
     - url: /careers-employment/vocational-rehabilitation/programs/
-      title: VR&E Programs for Servicemembers and Veterans
+      title: VR&E Programs for Service Members and Veterans
       description: Explore VR&E support-and-services tracks for help learning new skills, finding a new job, starting a business, getting educational counseling, or returning to your former job.
     - url: /careers-employment/vocational-rehabilitation/how-to-apply/
       title: How to Apply for VR&E
-      description: Find out how to apply for VR&E benefits and services as a Servicemember or Veteran.
+      description: Find out how to apply for VR&E benefits and services as a service member or Veteran.
     - url: /careers-employment/dependent-benefits/
       title: Dependent Family Members
-      description: If you're the dependent family member of a Servicemember or Veteran with a service-connected disability, find out if you may be eligible for certain counseling services, training, and education benefits.
+      description: If you're the dependent family member of a service member or Veteran with a service-connected disability, find out if you may be eligible for certain counseling services, training, and education benefits.
 aliases:
   - /employment/vocational-rehab-and-employment/eligibility/
 ---
@@ -52,7 +52,7 @@ You may be eligible for VR&E benefits and services if you’re a Veteran, and yo
 
 ### If I'm still on active duty, can I get VR&amp;E benefits and services?
 
-You may be eligible for VR&amp;E benefits and services if you're a Servicemember and you meet at least one of the requirements listed below.
+You may be eligible for VR&amp;E benefits and services if you're a service member and you meet at least one of the requirements listed below.
 
 **At least one of these must be true. You:**
 
@@ -60,7 +60,7 @@ You may be eligible for VR&amp;E benefits and services if you're a Servicemember
 - Are participating in the Integrated Disability Evaluation System (IDES) process or awaiting discharge due to a medical condition resulting from a serious injury or illness that occurred in the line of duty. <br>
 [Learn more about accessing VR&E services through IDES](/careers-employment/vocational-rehabilitation/ides/).
 
-**Please note:** Severely injured active-duty Servicemembers can automatically receive VR&E benefits before VA issues a disability rating, because of Sec. 1631(b) of the National Defense Authorization Act (PL 110-181). The sunset date of that law has been extended to September 30, 2018, through Sec. 724 of Public Law 113-291.
+**Please note:** Severely injured active-duty service members can automatically receive VR&E benefits before VA issues a disability rating, because of Sec. 1631(b) of the National Defense Authorization Act (PL 110-181). The sunset date of that law has been extended to September 30, 2018, through Sec. 724 of Public Law 113-291.
 
 <br>
 
@@ -82,7 +82,7 @@ You can apply online right now.
 <a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
 
 [Learn more about how to apply for VR&E](/careers-employment/vocational-rehabilitation/how-to-apply/). <br>
-**Note:** You can apply even if you're a Servicemember without a disability rating yet.
+**Note:** You can apply even if you're a service member without a disability rating yet.
 
 
 ### What kind of VR&E services can I get?
@@ -101,7 +101,7 @@ You can apply online right now.
 ### If I'm eligible for GI Bill benefits, can I get paid the Post-9/11 GI Bill subsistence rate for my VR&E program?
 If you're participating in a VR&E program and also qualify for Post-9/11 GI Bill benefits, you can choose to get paid the GI Bill subsistence rate instead of the Chapter 31 subsistence allowance rate. In most cases the GI Bill rate is higher.
 
-You'll need to officially choose the GI Bill subsistence rate. Your VRC can help you with this.<br> 
+You'll need to officially choose the GI Bill subsistence rate. Your VRC can help you with this.<br>
 [Contact your VRC for more information](/facilities/).<br>
 [View the current Chapter 31 subsistence allowance rates](https://benefits.va.gov/VOCREHAB/subsistence_allowance_rates.asp?_ga=2.203704281.836500684.1545080344-1582256389.1508352376).<br>
 [View the current Post-9/11 GI Bill benefit rates](/education/benefit-rates/).
@@ -112,7 +112,7 @@ You'll need to officially choose the GI Bill subsistence rate. Your VRC can help
 **We offer opportunities to get training and practical hands-on work experience at the same time through programs like:**
 - **The VR&E Special Employer Incentives (SEI) program** for eligible Veterans who face challenges getting a job. <br>
   [Download the SEI program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/SpecialEmployerIncentive.pdf).
-- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and Servicemembers who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
+- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and service members who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
   [Download the NPWE program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/Non-paidWorkExperience.pdf).<br>
   [Watch this video to learn more about the NPWE program](https://www.youtube.com/watch?v=t2J3RPQOiuM).
 

--- a/pages/careers-employment/vocational-rehabilitation/how-to-apply.md
+++ b/pages/careers-employment/vocational-rehabilitation/how-to-apply.md
@@ -8,11 +8,11 @@ relatedlinks:
   - heading: More information about VR&E benefits and services
     links:
     - url: /careers-employment/vocational-rehabilitation/programs/
-      title: VR&E Programs for Servicemembers and Veterans
+      title: VR&E Programs for Service Members and Veterans
       description: Explore VR&E support-and-services tracks for help learning new skills, finding a new job, starting a business, getting educational counseling, or returning to your former job.
     - url: /careers-employment/dependent-benefits/
       title: Dependent Family Members
-      description: If you're the dependent family member of a Servicemember or Veteran with a service-connected disability, find out if you may be eligible for certain counseling services, training, and education benefits.
+      description: If you're the dependent family member of a service member or Veteran with a service-connected disability, find out if you may be eligible for certain counseling services, training, and education benefits.
 aliases:
   - /employment/vocational-rehab-and-employment/apply-vre/
 ---
@@ -66,7 +66,7 @@ If you’re eligible, we’ll invite you to an orientation session at your neare
 
 <div class="feature" markdown=“1”>
 
-### What if I’m a Servicemember who hasn’t yet received a service-connected disability rating?
+### What if I’m a service member who hasn’t yet received a service-connected disability rating?
 
 You don’t need to wait for a rating. Instead, please fill out VA Vocational Rehabilitation - Getting Ahead After You Get Out (VA Form 28-0588). <br>
 [Download VA Form 28-0588](http://www.vba.va.gov/pubs/forms/VBA-28-0588-ARE.pdf).
@@ -79,7 +79,7 @@ You may be eligible for VR&amp;E benefits and services if you’re in at least o
 - Entered in the Integrated Disability Evaluation System (IDES). <br>
 [Learn more about accessing VR&E services through IDES](/careers-employment/vocational-rehabilitation/ides/).
 
-**Please note:** Severely injured active-duty Servicemembers can automatically receive VR&E benefits before VA issues a disability rating, because of Sec. 1631(b) of the National Defense Authorization Act (PL 110-181). The sunset date of that law has been extended to September 30, 2018, through Sec. 724 of Public Law 113-291.
+**Please note:** Severely injured active-duty service members can automatically receive VR&E benefits before VA issues a disability rating, because of Sec. 1631(b) of the National Defense Authorization Act (PL 110-181). The sunset date of that law has been extended to September 30, 2018, through Sec. 724 of Public Law 113-291.
 
 </div>
 
@@ -92,9 +92,9 @@ After we make an entitlement decision, you and your counselor will work together
 You can also meet with VRCs called VetSuccess on Campus (VSOC) Counselors at schools participating in the VetSuccess on Campus (VSOC) program. <br>
 [Learn more about VetSuccess on Campus](/careers-employment/vetsuccess-on-campus/).
 
-### What's included in a rehabilitation plan? 
+### What's included in a rehabilitation plan?
 
-A rehabilitation plan is a written plan that outlines the resources we'll use to help you find employment. Depending on your situation, your VRC will work with you to choose one of the following support-and-services tracks to help you find and keep a job, and live as independently as possible: 
+A rehabilitation plan is a written plan that outlines the resources we'll use to help you find employment. Depending on your situation, your VRC will work with you to choose one of the following support-and-services tracks to help you find and keep a job, and live as independently as possible:
 - [Reemployment with a former employer](/careers-employment/vocational-rehabilitation/programs/reemployment/)
 - [Job placement and counseling services for new employment](/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment/)
 - [Help with starting your own business ](/careers-employment/vocational-rehabilitation/programs/self-employment/)

--- a/pages/careers-employment/vocational-rehabilitation/programs.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs.md
@@ -1,6 +1,6 @@
 ---
 layout: page-breadcrumbs.html
-title: Vocational Rehab Programs for Veterans and Servicemembers
+title: Vocational Rehab Programs for Veterans and Service Members
 display_title: Programs
 order: 1
 template: detail-page
@@ -17,7 +17,7 @@ majorlinks:
         description: If you want a job that matches your existing skills, find out if you can get employment counseling and job-search support.
       - url: /careers-employment/vocational-rehabilitation/programs/self-employment/
         title: Self-Employment Track
-        description: If you’re a Servicemember or Veteran with a service-connected disability, find out how we can help you start your own business.
+        description: If you’re a service member or Veteran with a service-connected disability, find out how we can help you start your own business.
       - url: /careers-employment/vocational-rehabilitation/programs/long-term-services/
         title: Employment through Long-Term Services Track
         description: Find out if you may be eligible for vocational training to help you develop new job skills.
@@ -30,6 +30,6 @@ aliases:
 
 <div class="va-introtext">
 
-If you're a Veteran or Servicemember with a service-connected disability that impacts your ability to work, the Vocational Rehabilitation and Employment (VR&amp;E) program may be able to help. We offer 5 support-and-services tracks to help you find and keep a job, and live as independently as possible. Explore the different tracks—and find out how to apply for VR&E benefits and services.
+If you're a Veteran or service member with a service-connected disability that impacts your ability to work, the Vocational Rehabilitation and Employment (VR&amp;E) program may be able to help. We offer 5 support-and-services tracks to help you find and keep a job, and live as independently as possible. Explore the different tracks—and find out how to apply for VR&E benefits and services.
 
 </div>

--- a/pages/careers-employment/vocational-rehabilitation/programs/independent-living.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/independent-living.md
@@ -15,7 +15,7 @@ relatedlinks:
       description: If you want a job that matches your existing skills, find out if you can get employment counseling and job-search support.
     - url: /careers-employment/vocational-rehabilitation/programs/self-employment/
       title: Self-Employment Track
-      description: If you’re a Servicemember or Veteran with a service-connected disability, find out how we can help you start your own business.
+      description: If you’re a service member or Veteran with a service-connected disability, find out how we can help you start your own business.
     - url: /careers-employment/vocational-rehabilitation/programs/long-term-services/
       title: Employment through Long-Term Services Track
       description: Find out if you may be eligible for vocational training to help you develop new job skills.
@@ -35,7 +35,7 @@ Find out if you may be eligible for services to help you live as independently a
 
 ### Can I get independent living services through VR&amp;E?
 
-You may be eligible for independent living services if you’re a Servicemember or Veteran with a service-connected disability who is eligible for VR&E benefits, and you meet all of the requirements listed below.
+You may be eligible for independent living services if you’re a service member or Veteran with a service-connected disability who is eligible for VR&E benefits, and you meet all of the requirements listed below.
 
 **All of these must be true:**
 

--- a/pages/careers-employment/vocational-rehabilitation/programs/long-term-services.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/long-term-services.md
@@ -15,7 +15,7 @@ relatedlinks:
       description: If you want a job that matches your existing skills, find out if you can get employment counseling and job-search support.
     - url: /careers-employment/vocational-rehabilitation/programs/self-employment/
       title: Self-Employment Track
-      description: If you’re a Servicemember or Veteran with a service-connected disability, find out how we can help you start your own business.
+      description: If you’re a service member or Veteran with a service-connected disability, find out how we can help you start your own business.
     - url: /careers-employment/vocational-rehabilitation/programs/independent-living/
       title: Independent Living Track
       description: Learn about services that can help you live as independently as possible if you can't return to work right away.
@@ -35,7 +35,7 @@ Find out if you’re eligible for vocational counseling and  training with VR&E.
 
 ### Can I get vocational counseling and training for new skills through VR&amp;E?
 
-You may be eligible for these benefits if you’re a Servicemember or Veteran with a service-connected disability, and you meet all of the requirements listed below.
+You may be eligible for these benefits if you’re a service member or Veteran with a service-connected disability, and you meet all of the requirements listed below.
 
 **All of these must be true:**
 
@@ -114,7 +114,7 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 **We offer opportunities to get training and practical hands-on work experience at the same time through programs like:**
 - **The VR&E Special Employer Incentives (SEI) program** for eligible Veterans who face challenges getting a job. <br>
   [Download the SEI program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/SpecialEmployerIncentive.pdf).
-- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and Servicemembers who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
+- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and service members who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
   [Download the NPWE program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/Non-paidWorkExperience.pdf).<br>
   [Watch this video to learn more about the NPWE program](https://www.youtube.com/watch?v=t2J3RPQOiuM).
 

--- a/pages/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment.md
@@ -12,7 +12,7 @@ relatedlinks:
       description: You may have the right to return to the civilian job you held before activating. Find out how we can help with this process.
     - url: /careers-employment/vocational-rehabilitation/programs/self-employment/
       title: Self-Employment Track
-      description: If you’re a Servicemember or Veteran with a service-connected disability, find out how we can help you start your own business.
+      description: If you’re a service member or Veteran with a service-connected disability, find out how we can help you start your own business.
     - url: /careers-employment/vocational-rehabilitation/programs/long-term-services/
       title: Employment through Long-Term Services Track
       description: Find out if you may be eligible for vocational training to help you develop new job skills.
@@ -35,7 +35,7 @@ Find out if you can get VR&amp;E benefits and services to help you use your exis
 
 ### Can I get employment counseling and job-search support through VR&amp;E?
 
-You may be eligible for these benefits if you’re a Servicemember or Veteran with a service-connected disability, and you meet all of the requirements listed below.
+You may be eligible for these benefits if you’re a service member or Veteran with a service-connected disability, and you meet all of the requirements listed below.
 
 **All of these must be true. You:**
 - Have an employment handicap or barrier, **and**
@@ -100,7 +100,7 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 
 [Find out how to apply if you haven’t yet received a disability rating](/careers-employment/vocational-rehabilitation/how-to-apply/#servicemember-not-received-rating).
 
-Some dependents of Servicemembers or Veterans with service-connected disabilities may also be eligible for education and career counseling. <br>
+Some dependents of service members or Veterans with service-connected disabilities may also be eligible for education and career counseling. <br>
 [Learn about services for family members](/careers-employment/dependent-benefits/).
 
 <br>
@@ -110,7 +110,7 @@ Some dependents of Servicemembers or Veterans with service-connected disabilitie
 **We offer opportunities to get training and practical hands-on work experience at the same time through programs like:**
 - **The VR&E Special Employer Incentives (SEI) program** for eligible Veterans who face challenges getting a job. <br>
   [Download the SEI program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/SpecialEmployerIncentive.pdf).
-- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and Servicemembers who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
+- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and service members who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
   [Download the NPWE program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/Non-paidWorkExperience.pdf).<br>
   [Watch this video to learn more about the NPWE program](https://www.youtube.com/watch?v=t2J3RPQOiuM).
   

--- a/pages/careers-employment/vocational-rehabilitation/programs/reemployment.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/reemployment.md
@@ -12,7 +12,7 @@ relatedlinks:
       description: If you want a job that matches your existing skills, find out if you can get employment counseling and job-search support.
     - url: /careers-employment/vocational-rehabilitation/programs/self-employment/
       title: Self-Employment Track
-      description: If you’re a Servicemember or Veteran with a service-connected disability, find out how we can help you start your own business.
+      description: If you’re a service member or Veteran with a service-connected disability, find out how we can help you start your own business.
     - url: /careers-employment/vocational-rehabilitation/programs/long-term-services/
       title: Employment through Long-Term Services Track
       description: Find out if you may be eligible for vocational training to help you develop new job skills.
@@ -105,7 +105,7 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 **We offer opportunities to get training and practical hands-on work experience at the same time through programs like:**
 - **The VR&E Special Employer Incentives (SEI) program** for eligible Veterans who face challenges getting a job. <br>
   [Download the SEI program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/SpecialEmployerIncentive.pdf).
-- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and Servicemembers who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
+- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and service members who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
   [Download the NPWE program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/Non-paidWorkExperience.pdf).<br>
   [Watch this video to learn more about the NPWE program](https://www.youtube.com/watch?v=t2J3RPQOiuM).
 

--- a/pages/careers-employment/vocational-rehabilitation/programs/self-employment.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/self-employment.md
@@ -30,7 +30,7 @@ aliases:
 
 <div class="va-introtext">
 
-If you're a Servicemember or Veteran with a service-connected disability and an employment barrier who has the strong desire, skills, and drive to run a successful business, you may be interested in the Vocational Rehabilitation and Employment (VR&amp;E) Self-Employment track. Find out if you can get help starting your own business.
+If you're a service member or Veteran with a service-connected disability and an employment barrier who has the strong desire, skills, and drive to run a successful business, you may be interested in the Vocational Rehabilitation and Employment (VR&amp;E) Self-Employment track. Find out if you can get help starting your own business.
 
 </div>
 
@@ -38,7 +38,7 @@ If you're a Servicemember or Veteran with a service-connected disability and an 
 
 ### Can I get help starting my own business through the VR&amp;E Self-Employment track?
 
-You may be eligible for these benefits if you’re a Servicemember or Veteran with a service-connected disability, and you meet all of the requirements listed below.
+You may be eligible for these benefits if you’re a service member or Veteran with a service-connected disability, and you meet all of the requirements listed below.
 
 **All of these must be true:**
 
@@ -111,7 +111,7 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 **We offer opportunities to get training and practical hands-on work experience at the same time through programs like:**
 - **The VR&E Special Employer Incentives (SEI) program** for eligible Veterans who face challenges getting a job. <br>
   [Download the SEI program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/SpecialEmployerIncentive.pdf).
-- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and Servicemembers who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
+- **The VR&E Non-Paid Work Experience (NPWE) program** for eligible Veterans and service members who have an established career goal and learn easily in a hands-on environment—or are having trouble getting a job due to lack of work experience. <br>
   [Download the NPWE program fact sheet](https://benefits.va.gov/BENEFITS/factsheets/vocrehab/Non-paidWorkExperience.pdf).<br>
   [Watch this video to learn more about the NPWE program](https://www.youtube.com/watch?v=t2J3RPQOiuM).
 

--- a/pages/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft.md
+++ b/pages/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft.md
@@ -20,7 +20,7 @@ If you flew on—or worked with—C-123 aircraft in Vietnam or other locations, 
 
 <br>
 
-#### For Active-Duty Servicemembers
+#### For Active-Duty service members
 
 You may be able to get disability benefits if you have an illness believed to be caused by contact with Agent Orange and both of the below descriptions are true for you.
 

--- a/pages/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite.md
+++ b/pages/disability/eligibility/hazardous-materials-exposure/mustard-gas-lewisite.md
@@ -47,7 +47,7 @@ You may be able to get disability benefits if you have a disability believed to 
 - Naval Research Laboratory, Washington, DC
 - USS Eagle Boat 58
 
-**Some Servicemembers** who took part in testing in these places:
+**Some service members** who took part in testing in these places:
  - Finschhafen, New Guinea
  - Porton Down, England
  

--- a/pages/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment.md
+++ b/pages/disability/eligibility/special-claims/automobile-allowance-adaptive-equipment.md
@@ -13,7 +13,7 @@ aliases:
 
 <div class="va-introtext">
 
-Do you have a disability related to your military service that prevents you from driving? If you do, you may be able to get disability compensation or benefits. 
+Do you have a disability related to your military service that prevents you from driving? If you do, you may be able to get disability compensation or benefits.
 
 </div>
 
@@ -35,7 +35,7 @@ You may be able to get disability benefits if you have a disability that’s rel
 ### Who’s covered?
 
 - Veterans
-- Servicemembers
+- Service members
 </div>
 
 ### What kind of disability benefits can I get?
@@ -59,10 +59,10 @@ When you file, you’ll need to show that your disability is service connected o
 
 [View the current payment rates](https://www.benefits.va.gov/COMPENSATION/special_Benefit_Allowances_2017.asp).
 
-#### For the one-time payment to help you buy a specially equipped vehicle 
+#### For the one-time payment to help you buy a specially equipped vehicle
 - You’ll need to fill out an Application for Automobile or Other Conveyance and Adaptive Equipment (VA Form 21-4502). <br>
-[Download VA Form 21-4502](https://www.vba.va.gov/pubs/forms/VBA-21-4502-ARE.pdf). 
-- We’ll pay the vehicle’s seller directly. 
+[Download VA Form 21-4502](https://www.vba.va.gov/pubs/forms/VBA-21-4502-ARE.pdf).
+- We’ll pay the vehicle’s seller directly.
 
 #### For the adaptive-equipment grant
 - If you qualify for adaptive equipment only, you’ll need to fill out an Application for Adaptive Equipment—Motor Vehicle (VA Form 10-1394). <br>

--- a/pages/disability/eligibility/special-claims/temporary-rating-prestabilization.md
+++ b/pages/disability/eligibility/special-claims/temporary-rating-prestabilization.md
@@ -45,4 +45,4 @@ Veterans
 You’ll need to file a claim for disability compensation. When you file, you’ll have to show that you have a severe, service-connected disability that’s unstable and expected to continue for an unknown amount of time. This information will normally be part of your Service Treatment Record. <br>
 [Find out how to file a claim for disability compensation](/disability/how-to-file-claim/).
 
-**Example:** While in active service, a Servicemember was diagnosed with Hodgkin’s disease and began chemotherapy that continued during and after her medical discharge process. She continued to get treatment through her local VA medical center, and we gave her a prestabilization rating of 100% for 1 year from her date of discharge.
+**Example:** While in active service, a service member was diagnosed with Hodgkin’s disease and began chemotherapy that continued during and after her medical discharge process. She continued to get treatment through her local VA medical center, and we gave her a prestabilization rating of 100% for 1 year from her date of discharge.

--- a/pages/disability/get-help-filing-claim.md
+++ b/pages/disability/get-help-filing-claim.md
@@ -31,7 +31,7 @@ spoke: More Resources
 
 If you need help filing a claim or appeal, you may want to work with an accredited attorney, a claims agent, or a Veterans Service Officer (VSO). We trust these professionals because they’re trained and certified in the VA claims and appeals processes and can help you with VA-related needs.
 
-VSOs work on behalf of Veterans and Servicemembers—as well as their dependents and survivors. Find out more about accredited representatives and how they can help you.
+VSOs work on behalf of Veterans and service members—as well as their dependents and survivors. Find out more about accredited representatives and how they can help you.
 
 </div>
 
@@ -46,7 +46,7 @@ VSOs work on behalf of Veterans and Servicemembers—as well as their dependents
   - Pass a background check
   - Take continuing-education courses to make sure they’re providing the most up-to-date information
 
-Recognized organizations and individuals can legally represent a Veteran, Servicemember, dependent, or survivor before VA. Non-recognized organizations and individuals can provide information, but can’t be representatives.
+Recognized organizations and individuals can legally represent a Veteran, service member, dependent, or survivor before VA. Non-recognized organizations and individuals can provide information, but can’t be representatives.
 
 </div>
 </div>

--- a/pages/disability/how-to-file-claim/evidence-needed.md
+++ b/pages/disability/how-to-file-claim/evidence-needed.md
@@ -205,7 +205,7 @@ If you didn’t have surgery, you'll need to show that one or more of your major
 <div id="special-home" class="usa-accordion-content">
 
 **You'll need to submit both of these:** 
-- Evidence that shows you're a Veteran or Servicemember with a qualifying permanent and totally disabling service-connected disability<br>
+- Evidence that shows you're a Veteran or service member with a qualifying permanent and totally disabling service-connected disability<br>
 [Find out if you have a qualifying service-connected disability](/housing-assistance/disability-housing-grants/). <br> 
 **and** <br>
 - An Application in Acquiring Specially Adapted Housing or Special Home Adaptation Grant (VA Form 26-4555)<br>

--- a/pages/disability/how-to-file-claim/when-to-file/pre-discharge-claim.md
+++ b/pages/disability/how-to-file-claim/when-to-file/pre-discharge-claim.md
@@ -37,7 +37,7 @@ You can use the BDD program if you meet all of the requirements listed below.
 
 **All of these must be true:**
 
-* You’re a Servicemember on full-time active duty (including a member of the National Guard, Reserves, or Coast Guard), **and**
+* You’re a service member on full-time active duty (including a member of the National Guard, Reserves, or Coast Guard), **and**
 * You have a known separation date, **and**
 * Your separation date is in the next 180 to 90 days
 

--- a/pages/disability/index.md
+++ b/pages/disability/index.md
@@ -19,7 +19,7 @@ crosslinks:
     links:
     - url: /housing-assistance/disability-housing-grants/
       title: <b>Disability Housing Grants for Veterans</b>
-      description: Find out how to apply for a housing grant as a Veteran or Servicemember with a service-connected disability.
+      description: Find out how to apply for a housing grant as a Veteran or service member with a service-connected disability.
     - url: https://www.benefits.va.gov/fiduciary/index.asp
       title: <b>Fiduciary Services</b>
       description: Learn how to become a VA fiduciary to handle the financial affairs of a Veteran in need.

--- a/pages/disability/upload-supporting-evidence.md
+++ b/pages/disability/upload-supporting-evidence.md
@@ -87,7 +87,7 @@ If you’ve seen a non-VA health care provider for diagnosis or treatment, you�
 If you’re claiming a disability for an injury or illness that you don’t think we have in your military records, you’ll also want to upload statements that support your claim. These statements should be from people who know about, or who you’ve talked to about, your claimed medical condition and how and when it occurred.
 
 **You can ask for supporting statements from people like:**
-- Servicemembers who served with you
+- Service members who served with you
 - Your family and friends
 - Clergy members
 - Law enforcement officers

--- a/pages/education/about-gi-bill-benefits.md
+++ b/pages/education/about-gi-bill-benefits.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: About GI Bill Benefits
 display_title: GI Bill
-description: Learn how GI Bill benefits work and explore your options to pay for school or training. You may qualify for VA GI Bill benefits if you're a Veteran, Servicemember, or the family member of a Veteran or Servicember.
+description: Learn how GI Bill benefits work and explore your options to pay for school or training. You may qualify for VA GI Bill benefits if you're a Veteran, service member, or the family member of a Veteran or Servicember.
 concurrence: incomplete
 plainlanguage: 11-29-16 certified in compliance with the Plain Writing Act.
 collection: education

--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/non-college-degree-programs.md
@@ -28,7 +28,7 @@ You can get education benefits through the GI Bill if you meet both of the requi
 
 ### Who’s covered?
 - Veterans
-- Servicemembers
+- Service members
 - Qualified dependents
 
 </div>
@@ -53,5 +53,3 @@ The amount you get depends on which GI Bill program you use and what school you 
 - **Post-9/11 GI Bill:** For training offered at non-degree schools, we pay the in-state tuition and fees up to the national maximum.
 
 - **Other GI Bill programs:** We pay a monthly rate that depends on your specific program and your length of active service.
-
-

--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/on-the-job-training-apprenticeships.md
@@ -41,7 +41,7 @@ You can get benefits if you qualify for the GI Bill and want to work in an indus
  - Children getting transferred benefits under the Post-9/11 GI Bill (also called chapter 33)
 
 **Exception:**
-You can’t get OJT if you’re an active-duty Servicemember or a spouse using a transferred benefit.
+You can’t get OJT if you’re an active-duty service member or a spouse using a transferred benefit.
 
 </div>
 </div>

--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/study-at-foreign-schools.md
@@ -21,7 +21,7 @@ If you plan to study at a foreign school, find out how you can use VA benefits t
 You can get education benefits if you meet all of the requirements listed below.
 
 **All of these must be true:**
-  - You're eligible for—or already get—VA educational assistance as a Veteran, Servicemember, Reservist, or qualified dependent, **and**
+  - You're eligible for—or already get—VA educational assistance as a Veteran, service member, Reservist, or qualified dependent, **and**
   - We’ve approved your program, **and**
   - Your program is at an institution of higher learning where you’ll earn a standard associate's degree or higher, or a degree of equal value at that foreign school. 
 

--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/test-fees.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/test-fees.md
@@ -49,7 +49,7 @@ If you’re a Veteran and you qualify for the GI Bill, you may be able to use pa
   
 <div id="national-testing-kinds-of-benefits" class="usa-accordion-content">
   
-### If you’re a Veteran or Servicemember and you qualify for the GI Bill, we may pay you back for testing fees
+### If you’re a Veteran or service member and you qualify for the GI Bill, we may pay you back for testing fees
 
 **These include:**
 

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -34,7 +34,7 @@ You can get these education benefits if you meet at least one of the requirement
 - Served at least 90 days on active duty (either all at once or with breaks in service) on or after September 11, 2001, **or**
 - Received a Purple Heart on or after September 11, 2001, and were honorably discharged after any amount of service, **or**
 - Served for at least 30 continuous days (all at once, without a break in service) on or after September 11, 2001, and were honorably discharged with a service-connected disability, **or**
-- Are a dependent child using benefits transferred by a qualifying Veteran or Servicemember
+- Are a dependent child using benefits transferred by a qualifying Veteran or service member
 
 **Note:** If you're a member of the Reserves who lost education benefits when the Reserve Educational Assistance Program (REAP) ended in November 2015, you may qualify to receive restored benefits under the Post-9/11 GI Bill.
 
@@ -138,9 +138,9 @@ If you already applied for and were awarded Post-9/11 GI Bill education benefits
 
 - If you need more money to cover higher private-school or out-of-state tuition, you can apply for the Yellow Ribbon Program. <br>
 [Learn about the Yellow Ribbon Program](/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/).
-- If you’re a qualified Servicemember, you can transfer all 36 months or a portion of your Post-9/11 GI Bill benefits to a spouse or child. The Department of Defense approves a transfer of benefits. <br>
+- If you’re a qualified service member, you can transfer all 36 months or a portion of your Post-9/11 GI Bill benefits to a spouse or child. The Department of Defense approves a transfer of benefits. <br>
 [Learn about transferring Post-9/11 GI Bill benefits](/education/transfer-post-9-11-gi-bill-benefits/).
-- If you're the child or surviving spouse of a Servicemember who died in the line of duty after September 10, 2001, you may qualify for the Marine Gunnery Sergeant John David Fry Scholarship (Fry Scholarship). <br>
+- If you're the child or surviving spouse of a service member who died in the line of duty after September 10, 2001, you may qualify for the Marine Gunnery Sergeant John David Fry Scholarship (Fry Scholarship). <br>
 [Learn more about the Fry Scholarship](/education/survivor-dependent-benefits/fry-scholarship/).
 
 </div>

--- a/pages/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program.md
@@ -31,12 +31,12 @@ You may be eligible for this program if you and your school meet the requirement
 - Received a Purple Heart on or after September 11, 2001, and were honorably discharged after any amount of service, **or**
 - Received a Fry scholarship on or after August 1, 2018, **or**
 - Served for at least 30 continuous days (all at once, without a break) on or after September 11, 2001, and were discharged after 60 days with a service-connected disability, **or**
-- Are a dependent child using benefits transferred by a Veteran or a Servicemember who has served for at least 36 months on active duty and qualifies at the 100% level, **or** </br>
+- Are a dependent child using benefits transferred by a Veteran or a service member who has served for at least 36 months on active duty and qualifies at the 100% level, **or** </br>
 [Find out about transferring Post-9/11 GI Bill benefits](/education/transfer-post-9-11-gi-bill-benefits/).
 - Are receiving the Fry Scholarship (beginning August 1, 2018) <br>
 [Learn more about the Fry Scholarship](/education/survivor-dependent-benefits/fry-scholarship/).
 
-**Note:** At this time, you're not eligible for the maximum benefit rate under the Post-9/11 GI Bill if you're an active-duty Servicemember or the spouse of an active-duty Servicemember. But, as of August 1, 2022, you may become eligible if you're an active-duty Servicemember who qualifies at the 100% level, or the spouse using the transferred benefits of an active-duty Servicemember who qualifies at the 100% level.
+**Note:** At this time, you're not eligible for the maximum benefit rate under the Post-9/11 GI Bill if you're an active-duty service member or the spouse of an active-duty service member. But, as of August 1, 2022, you may become eligible if you're an active-duty service member who qualifies at the 100% level, or the spouse using the transferred benefits of an active-duty service member who qualifies at the 100% level.
 
 #### And your school must meet certain requirements.
 

--- a/pages/education/change-gi-bill-benefits.md
+++ b/pages/education/change-gi-bill-benefits.md
@@ -27,12 +27,12 @@ You'll need to request changes to your benefits if any of the descriptions below
 
 <h2>How do I request changes to my benefits?</h2>
 
-<h3>If you're a Veteran or Servicemember</h3>
+<h3>If you're a Veteran or service member</h3>
 
 You'll need to submit a Request for Change of Program or Place of Training (VA Form 22-1995). You can complete this form online now.<br>
 [Complete VA Form 22-1995 online](/education/apply-for-education-benefits/application/1995/introduction).
 
-<h3>If you're the dependent of a Veteran or Servicemember</h3>
+<h3>If you're the dependent of a Veteran or service member</h3>
 
 You'll need to submit a Dependent's Request for Change of Program or Place of Training (VA Form 22-5495). You can complete this form online now.<br>
 [Complete VA Form 22-5495 online](/education/apply-for-education-benefits/application/5495/introduction).
@@ -50,7 +50,7 @@ You'll need to submit a Dependent's Request for Change of Program or Place of Tr
 - Education or training plans and goals
 - Current or former school or training program and the new school or training program you plan to attend
 
-<b>If you're the dependent of a Veteran or Servicemember, you'll also need that person's:</b>
+<b>If you're the dependent of a Veteran or service member, you'll also need that person's:</b>
 - Social Security number or VA file number
 - Basic service history information
 
@@ -63,7 +63,7 @@ Yes. Follow the steps below to submit your request by mail, in person, or with t
 <h3>By mail</h3>
 
 Download the form you'll need:<br>
-[Download VA Form 22-1995 for Veterans and Servicemembers](https://www.vba.va.gov/pubs/forms/vba-22-1995-are.pdf).<br>
+[Download VA Form 22-1995 for Veterans and service members](https://www.vba.va.gov/pubs/forms/vba-22-1995-are.pdf).<br>
 [Download VA Form 22-5495 for Dependents](https://www.vba.va.gov/pubs/forms/vba-22-5495-are.pdf).
 
 Fill out the form and mail it to the VA regional claims processing office that’s in the same region as your school.<br>

--- a/pages/education/choosing-a-school/principles-of-excellence.md
+++ b/pages/education/choosing-a-school/principles-of-excellence.md
@@ -24,7 +24,7 @@ Schools that are a part of the program must:
   - Other information to help you compare aid packages offered by different schools.
 - Give you an educational plan with a timeline showing how and when you can fulfill everything required for you to graduate.
 - Assign you a point of contact who will give you ongoing academic and financial advice (including access to disability counseling).
-- Allow for you to be gone for both long and short periods of time due to service obligations (service you must fulfill) for active-duty Servicemembers and Reservists.
+- Allow for you to be gone for both long and short periods of time due to service obligations (service you must fulfill) for active-duty service members and Reservists.
 - Make sure all new programs are accredited (officially approved) before enrolling students.
 - Make sure their refund policies follow Title IV rules, which guide federal student financial aid programs.
 - End fraudulent (deceitful) and aggressive methods of recruiting.

--- a/pages/education/eligibility.md
+++ b/pages/education/eligibility.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Eligibility for the GI Bill and Other Education Benefits
 display_title: Eligibility
-description: Review GI Bill eligibility requirements to find out if you can get help paying for school or training. You can also find out if you qualify for other VA education benefits as a Veteran, Servicemember, Reservist, National Guard Soldier, or qualified survivor or dependent.
+description: Review GI Bill eligibility requirements to find out if you can get help paying for school or training. You can also find out if you qualify for other VA education benefits as a Veteran, service member, Reservist, National Guard Soldier, or qualified survivor or dependent.
 plainlanguage: 11-02-16 certified in compliance with the Plain Writing Act
 collection: education
 spoke: Get Benefits
@@ -18,7 +18,7 @@ gibsAlert: false
 <div itemscope itemtype="http://schema.org/FAQPage">
 <div class="va-introtext" itemprop="description" >
 
-If you’re an active-duty Servicemember or Veteran, a member of the National Guard or Reserves, or a qualified survivor or dependent, you may be able to get help from VA to pay your tuition, pick out a school, choose a career, and more. Find out if you qualify for VA education benefits through the GI Bill program and other educational assistance programs.
+If you’re an active-duty service member or Veteran, a member of the National Guard or Reserves, or a qualified survivor or dependent, you may be able to get help from VA to pay your tuition, pick out a school, choose a career, and more. Find out if you qualify for VA education benefits through the GI Bill program and other educational assistance programs.
 
 </div>
 

--- a/pages/education/how-to-apply.md
+++ b/pages/education/how-to-apply.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: How to Apply for the GI Bill and Other Education Benefits
 display_title: How to Apply
-description: Find out how to apply for the GI Bill and other VA education benefits as a Veteran, Servicemember, or qualified family member. You can apply online, by mail, in person, or with the help of a trained professional.
+description: Find out how to apply for the GI Bill and other VA education benefits as a Veteran, service member, or qualified family member. You can apply online, by mail, in person, or with the help of a trained professional.
 plainlanguage: 11-02-16 certified in compliance with the Plain Writing Act.
 collection: education
 spoke: Get Benefits
@@ -34,7 +34,7 @@ aliases:
 <div itemscope itemtype ="http://schema.org/HowTo">
 <div class="va-introtext" itemprop="description">
 
-Find out how to apply for VA education benefits as a Veteran, Servicemember, or qualified family member.
+Find out how to apply for VA education benefits as a Veteran, service member, or qualified family member.
 
 </div>
 

--- a/pages/education/index.md
+++ b/pages/education/index.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: level2-index
 title: VA Education and Training Benefits
 display_title: Education and Training
-description: Find out if you're eligible and how to apply for VA education benefits for Veterans, Servicemembers, and their qualified family members. VA education and training benefits can help you pay for college tuition, find the right school or training program, get career counseling, and more.
+description: Find out if you're eligible and how to apply for VA education benefits for Veterans, service members, and their qualified family members. VA education and training benefits can help you pay for college tuition, find the right school or training program, get career counseling, and more.
 concurrence: complete
 lastupdate:
 order: 1
@@ -211,8 +211,8 @@ hublinks:
       description: Download VA education benefits forms, fact sheets, and other resources.
       external: false
     - url: https://www.benefits.va.gov/gibill/my_story.asp
-      label: My Story—How Veterans and Servicemembers Use the GI Bill
-      description: Hear inspiring stories from Veterans and Servicemembers who’ve advanced
+      label: My Story—How Veterans and service members Use the GI Bill
+      description: Hear inspiring stories from Veterans and service members who’ve advanced
         their education and training with the Post-9/11 GI Bill.
       external: false
     - url: https://www.benefits.va.gov/gibill/non_va_resources.asp
@@ -223,7 +223,7 @@ hublinks:
 ---
 
 <p class="va-introtext">
-VA education benefits help Veterans, Servicemembers, and their qualified family members with needs like paying college tuition, finding the right school or training program, and getting career counseling. Learn how to apply for and manage the education and training benefits you've earned.
+VA education benefits help Veterans, service members, and their qualified family members with needs like paying college tuition, finding the right school or training program, and getting career counseling. Learn how to apply for and manage the education and training benefits you've earned.
 </p>
 
 <h3>On This Page</h3>

--- a/pages/education/opt-out-information-sharing.md
+++ b/pages/education/opt-out-information-sharing.md
@@ -53,6 +53,6 @@ You’ll need to fill out a short form to tell us you want to opt out of sharing
 <b>Note</b>: If you’re signed in to your account, we can prefill part of your application based on your account details.
 
 ### What’s the Colmery Act?
-The Harry W. Colmery Veterans Educational Assistance Act, also called the “Forever GI Bill,” was signed into law August 2017 and expands education benefits for Veterans, Servicemembers, and their family members.
+The Harry W. Colmery Veterans Educational Assistance Act, also called the “Forever GI Bill,” was signed into law August 2017 and expands education benefits for Veterans, service members, and their family members.
 
 [Learn more about the Colmery Veterans Educational Assistance Act](https://www.benefits.va.gov/GIBILL/ForeverGIBill.asp).

--- a/pages/education/survivor-dependent-benefits.md
+++ b/pages/education/survivor-dependent-benefits.md
@@ -24,9 +24,9 @@ If you’re a dependent spouse or child—or the surviving spouse or child—of 
 
 ### Can I get education benefits?
 
-**You may qualify for education benefits if you’re the child or spouse of a Servicemember** and one of the below descriptions is true of the Servicemember.
+**You may qualify for education benefits if you’re the child or spouse of a service member** and one of the below descriptions is true of the service member.
 
-**One of these must be true. The Servicemember:**
+**One of these must be true. The service member:**
 
 - Died in the line of duty after September 10, 2001, **or**
 - Is missing in action or was captured in the line of duty by a hostile force, **or**
@@ -39,7 +39,7 @@ If you’re a dependent spouse or child—or the surviving spouse or child—of 
 - Is permanently and totally disabled due to a service-connected disability, **or**
 -	Died while on active duty or as a result of a service-connected disability
 
-If you’re a dependent who doesn’t meet the above criteria, you may still qualify for education benefits if the Veteran or Servicemember transferred some or all of their Post-9/11 GI Bill entitlement to you while they were on active duty. <br>
+If you’re a dependent who doesn’t meet the above criteria, you may still qualify for education benefits if the Veteran or service member transferred some or all of their Post-9/11 GI Bill entitlement to you while they were on active duty. <br>
 [Learn about transferred benefits](/education/transfer-post-9-11-gi-bill-benefits/).
 
 </div>
@@ -60,7 +60,7 @@ You’ll need to apply. <br>
 
 There are 2 main GI Bill programs offering educational assistance to survivors and dependents of Veterans:
 
-- The Marine Gunnery Sergeant John David Fry Scholarship (Fry Scholarship) is for children and spouses of Servicemembers who died in the line of duty after September 10, 2001. <br>
+- The Marine Gunnery Sergeant John David Fry Scholarship (Fry Scholarship) is for children and spouses of service members who died in the line of duty after September 10, 2001. <br>
 [Get more information about the Fry Scholarship](/education/survivor-dependent-benefits/fry-scholarship/).
 - The Survivors' and Dependents' Educational Assistance (DEA) program offers education and training to qualified dependents of Veterans who are permanently and totally disabled because of a service-related condition or who died while on active duty or as a result of a service-related condition. <br>
 [Get more information about the DEA program](/education/survivor-dependent-benefits/dependents-education-assistance/).
@@ -95,10 +95,10 @@ There are 2 main GI Bill programs offering educational assistance to survivors a
 
   <tr>
     <th scope="row"><strong>Duration of Benefits</strong></th>
-    <td><strong>Spouses:</strong> 20 years from the Servicemember’s date of death if they died on active duty, or 10 years from the date we determine they qualify or from the Veteran’s date of death (there may be exceptions). <br />
+    <td><strong>Spouses:</strong> 20 years from the service member’s date of death if they died on active duty, or 10 years from the date we determine they qualify or from the Veteran’s date of death (there may be exceptions). <br />
     <strong>Children:</strong> May use benefits between ages 18 and 26 (there may be exceptions).
   </td>
-  <td><strong>Spouses:</strong> 15 years from the Servicemember’s date of death (but spouses lose this benefit if they remarry). <br />
+  <td><strong>Spouses:</strong> 15 years from the service member’s date of death (but spouses lose this benefit if they remarry). <br />
   <strong>Children:</strong> Qualify as of their 18th birthday, and can use this benefit until their 33rd birthday.
   </td>
   </tr>

--- a/pages/education/survivor-dependent-benefits/dependents-education-assistance.md
+++ b/pages/education/survivor-dependent-benefits/dependents-education-assistance.md
@@ -12,7 +12,7 @@ aliases:
 
 <div class="va-introtext">
 
-If you’re the child or spouse of a Veteran or Servicemember who has died, is captured or missing, or has disabilities, find out if you can get help paying for school or job training through the Survivors’ and Dependents’ Educational Assistance (DEA) program—also called Chapter 35.
+If you’re the child or spouse of a Veteran or service member who has died, is captured or missing, or has disabilities, find out if you can get help paying for school or job training through the Survivors’ and Dependents’ Educational Assistance (DEA) program—also called Chapter 35.
 
 </div>
 
@@ -20,9 +20,9 @@ If you’re the child or spouse of a Veteran or Servicemember who has died, is c
 
 ### Can I get education benefits through the DEA program?
 
-You may be able to get these benefits if both you and the Veteran or Servicemember meet certain eligibility requirements.
+You may be able to get these benefits if both you and the Veteran or service member meet certain eligibility requirements.
 
-**One of the descriptions below must be true. The Veteran or Servicemember:**
+**One of the descriptions below must be true. The Veteran or service member:**
 
 - Is permanently and totally disabled due to a service-connected disability, **or**
 - Died while on active duty or as a result of a service-connected disability, **or**
@@ -30,18 +30,18 @@ You may be able to get these benefits if both you and the Veteran or Servicememb
 - Was forcibly detained (held) or interned in the line of duty by a foreign entity, **or**
 - Is in the hospital or getting outpatient treatment for a service-connected permanent and total disability and is likely to be discharged for that disability (effective December 23, 2006)
 
-### If you're the child of a Veteran or Servicemember
+### If you're the child of a Veteran or service member
 
 - You can get benefits if you’re between the ages of 18 and 26, except in certain cases. You may be married or unmarried.
 - If you’re over 18 years old and using DEA, you can’t get Dependency and Indemnity Compensation (DIC) from us. <br>
 [Learn about DIC](https://www.benefits.va.gov/COMPENSATION/types-dependency_and_indemnity.asp)
 - If you join the military, you can’t use this benefit while on active duty. And if you want to use this benefit after you leave the service, you can't have a dishonorable discharge. Military service can extend your eligibility, but this increase doesn’t usually go past your 31st birthday.
 
-### If you're the spouse of a Veteran or Servicemember
+### If you're the spouse of a Veteran or service member
 
 - Your benefits start on the date we conclude that you qualify or on the date of the Veteran’s death, and last for 10 years.
 - If we rated the Veteran as permanently and totally disabled, with an effective date that’s 3 years after discharge, you’ll qualify for benefits for 20 years from that effective date. This new policy began on October 10, 2008. We won’t pay benefits for training you started before this date.
-- If the Servicemember died on active duty, your benefits end 20 years from the date of death.
+- If the service member died on active duty, your benefits end 20 years from the date of death.
 - You can get DIC payments from us and use DEA benefits.
 
 </div>
@@ -64,7 +64,7 @@ We’ll make a monthly payment to your school to help cover the cost of:
 You'll need to pick one or the other. Once you make this choice, you can’t switch to the other program. <br>
 [Learn about the Fry Scholarship](/education/survivor-dependent-benefits/fry-scholarship/)
 
-**Exception:** If you’re the child of a Servicemember who died in the line of duty before August 1, 2011, you can use both DEA and the Fry Scholarship and get up to 81 months of education and training. You'll need to use one program at a time.
+**Exception:** If you’re the child of a service member who died in the line of duty before August 1, 2011, you can use both DEA and the Fry Scholarship and get up to 81 months of education and training. You'll need to use one program at a time.
 
 ### Can I get more help if I have a disability that prevents me from working toward my goals?
 

--- a/pages/education/survivor-dependent-benefits/fry-scholarship.md
+++ b/pages/education/survivor-dependent-benefits/fry-scholarship.md
@@ -11,7 +11,7 @@ aliases:
 
 <div class="va-introtext">
 
-If your parent or spouse was an active-duty Servicemember who died in the line of duty on or after September 11, 2001, you may qualify for the Marine Gunnery Sergeant John David Fry Scholarship (Fry Scholarship). Find out if you can get benefits through this scholarship.
+If your parent or spouse was an active-duty service member who died in the line of duty on or after September 11, 2001, you may qualify for the Marine Gunnery Sergeant John David Fry Scholarship (Fry Scholarship). Find out if you can get benefits through this scholarship.
 
 </div>
 
@@ -19,9 +19,9 @@ If your parent or spouse was an active-duty Servicemember who died in the line o
 
 ### Can I get Fry Scholarship benefits?
 
-You may be able to get benefits under the Fry Scholarship if you’re the child or surviving spouse of an active-duty Servicemember who died in the line of duty on or after September 11, 2001.
+You may be able to get benefits under the Fry Scholarship if you’re the child or surviving spouse of an active-duty service member who died in the line of duty on or after September 11, 2001.
 
-#### As the child of a Servicemember
+#### As the child of a service member
 
 - You can be married or unmarried.
 - **If you turned 18 or graduated from high school before January 1, 2013,** you can get a Fry Scholarship until you're 33 years old.
@@ -32,7 +32,7 @@ You may be able to get benefits under the Fry Scholarship if you’re the child 
 [Read about DIC](https://www.benefits.va.gov/COMPENSATION/types-dependency_and_indemnity.asp).
 
 
-#### As the spouse of a Servicemember
+#### As the spouse of a service member
 
 - **If you remarry,** you'll no longer be eligible for the Fry Scholarship.
 - You can still get Dependency and Indemnity Compensation (DIC) payments while using the Fry Scholarship.<br>

--- a/pages/education/transfer-post-9-11-gi-bill-benefits.md
+++ b/pages/education/transfer-post-9-11-gi-bill-benefits.md
@@ -98,7 +98,7 @@ These conditions apply to family members using transferred benefits:
 - Don’t have to use the benefit within 15 years after your separation from active duty, but can’t use the benefit after they’ve turned 26 years old.
 
 
-Your dependents may still qualify even if a child marries or you and your spouse divorce. However, Servicemembers and Veterans can revoke (cancel) or change a TOE at any time. If you want to totally revoke transferred benefits for a dependent and you’re still in the service, please turn in another transfer request for the dependent through milConnect. If a dependent’s transfer eligibility (ability to get a TOE) has been totally revoked, you can’t transfer benefits again to that dependent.
+Your dependents may still qualify even if a child marries or you and your spouse divorce. However, service members and Veterans can revoke (cancel) or change a TOE at any time. If you want to totally revoke transferred benefits for a dependent and you’re still in the service, please turn in another transfer request for the dependent through milConnect. If a dependent’s transfer eligibility (ability to get a TOE) has been totally revoked, you can’t transfer benefits again to that dependent.
 
 </div>
 </div>

--- a/pages/family-member-benefits.md
+++ b/pages/family-member-benefits.md
@@ -94,7 +94,7 @@ hublinks:
         description: Apply for a Certificate of Eligibility (COE) for VA home loan programs to buy, build, repair, or refinance a home. Or, if you're having trouble making mortgage payments on a VA-backed loan, get help to avoid foreclosure and keep your house. <br> <b>For surviving spouse</b>
       - url: /life-insurance/
         label: Life insurance options, claims, and beneficiary assistance
-        description: Learn how to apply for Family Servicemembers' Group Life Insurance (FSGLI) coverage, explore other coverage options, and manage an existing policy. If you're the beneficiary of a Veteran's or service member's policy, find out how to get free financial advice and will preparation services. <br> <b>For spouse, dependent child, surviving spouse, surviving child</b>
+        description: Learn how to apply for Family service members' Group Life Insurance (FSGLI) coverage, explore other coverage options, and manage an existing policy. If you're the beneficiary of a Veteran's or service member's policy, find out how to get free financial advice and will preparation services. <br> <b>For spouse, dependent child, surviving spouse, surviving child</b>
       - url: /burials-memorials/pre-need-eligibility/
         label: Pre-need eligibility determination for burial in a VA national cemetery
         description: Apply in advance for eligiblity to be buried in a VA national cemetery. This can help you plan ahead to make the burial process easier for your family in their time of need. <br> <b>For spouse, dependent child, surviving spouse, surviving child</b>

--- a/pages/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services.md
+++ b/pages/health-care/about-va-health-benefits/vision-care/blind-low-vision-rehab-services.md
@@ -28,7 +28,7 @@ relatedlinks:
 
 <div class="va-introtext">
 
-If you’re a Veteran or active-duty Servicemember who is blind or has low vision, you may be able to get advanced vision care and rehabilitation services through VA to help you live an independent life.
+If you’re a Veteran or active-duty service member who is blind or has low vision, you may be able to get advanced vision care and rehabilitation services through VA to help you live an independent life.
 
 </div>
 

--- a/pages/health-care/family-caregiver-benefits.md
+++ b/pages/health-care/family-caregiver-benefits.md
@@ -42,7 +42,7 @@ If you’re the spouse, surviving spouse, dependent child, or family caregiver o
 
 ### TRICARE
 
-If you’re the family member of an active-duty, retired, or deceased Servicemember, National Guard Soldier, Reservist, or Medal of Honor recipient, you may qualify for the TRICARE program.
+If you’re the family member of an active-duty, retired, or deceased service member, National Guard Soldier, Reservist, or Medal of Honor recipient, you may qualify for the TRICARE program.
 
 TRICARE provides comprehensive health coverage, including health plans, prescription medicines, dental plans, and programs for people with special needs. The Department of Defense’s Defense Health Agency manages this program. <br>
 [Find out if you qualify for TRICARE and how to apply](https://www.tricare.mil/).

--- a/pages/health-care/family-caregiver-benefits/champva.md
+++ b/pages/health-care/family-caregiver-benefits/champva.md
@@ -13,7 +13,7 @@ aliases:
 
 <div class="va-introtext">
 
-Are you the spouse or surviving spouse of—or a child of—a Veteran with disabilities or a Veteran who has died? If you don’t qualify for TRICARE (the Department of Defense’s health care program for active-duty and retired Servicemembers and their families), you may be able to get health insurance through the Civilian Health and Medical Program of the Department of Veterans Affairs (CHAMPVA).
+Are you the spouse or surviving spouse of—or a child of—a Veteran with disabilities or a Veteran who has died? If you don’t qualify for TRICARE (the Department of Defense’s health care program for active-duty and retired service members and their families), you may be able to get health insurance through the Civilian Health and Medical Program of the Department of Veterans Affairs (CHAMPVA).
 
 Through this program, we cover the cost of some of your health care services and supplies. This is called cost sharing. Find out if you qualify for CHAMPVA and how to apply.
 
@@ -30,7 +30,7 @@ You can only get health care through CHAMPVA if you don’t qualify for TRICARE 
 * The spouse or child of a Veteran who’s been rated permanently and totally disabled for a service-connected disability by a VA regional benefit office, **or**
 * The surviving spouse or child of a Veteran who died from a VA-rated service-connected disability, **or**
 * The surviving spouse or child of a Veteran who was at the time of death rated permanently and totally disabled from a service-connected disability, **or**
-* The surviving spouse or child of a Servicemember who died in the line of duty, not due to misconduct (in most of these cases, family members qualify for TRICARE, not CHAMPVA).
+* The surviving spouse or child of a service member who died in the line of duty, not due to misconduct (in most of these cases, family members qualify for TRICARE, not CHAMPVA).
 
 A service-connected disability is a disability that we’ve concluded was caused—or made worse—by the Veteran’s active-duty service. A permanent disability is one that's not expected to improve.
 

--- a/pages/health-care/health-needs-conditions/mental-health.md
+++ b/pages/health-care/health-needs-conditions/mental-health.md
@@ -106,7 +106,7 @@ Yes. You may be able to use one or more of the care options listed below.
 
 ### Can I speak to a fellow Veteran who's been through this before?
 
-Yes. The **BeThere** peer assistance program, in partnership with Military OneSource, offers support to Servicemembers (including National Guard Soldiers and Reservists), their families, and transitioning Veterans up to 365 days after separation or retirement. Through this program, you can talk privately with peer coaches who are Veterans, Servicemembers, or military spouses.
+Yes. The **BeThere** peer assistance program, in partnership with Military OneSource, offers support to service members (including National Guard Soldiers and Reservists), their families, and transitioning Veterans up to 365 days after separation or retirement. Through this program, you can talk privately with peer coaches who are Veterans, service members, or military spouses.
 
 To talk with a peer coach, call Military OneSource's free, confidential peer support services at <a href="tel:+1800-342-9647">1-800-342-9647</a>. This service is available 24 hours a day, 365 days a year.
 
@@ -277,14 +277,14 @@ You can also get support from resources offered by other government departments 
 <div class="usa-accordion">
 <ul class="usa-unstyled-list">
 <li>
-<button class="usa-button-unstyled usa-accordion-button" aria-controls="resources-veterans">Mental Health Resources for Veterans, Servicemembers, and Families</button>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="resources-veterans">Mental Health Resources for Veterans, service members, and Families</button>
 <div id="resources-veterans" class="usa-accordion-content">
 
 <strong>[Military OneSource](https://www.militaryonesource.mil/mental-health)</strong><br>
 This free service provides expert support to connect military personnel and their families with the best available resources to fit their needs. For support, visit the Military OneSource website or call <a href="tel:+1800-342-9647">1-800-342-9647</a> anytime, day or night.
 
 <strong>[The Psychological Health Resource Center](http://pdhealth.mil/)</strong><br>
-The center works to improve the lives of Veterans, Servicemembers, and their families by advancing excellence in psychological health care, readiness, and prevention.
+The center works to improve the lives of Veterans, service members, and their families by advancing excellence in psychological health care, readiness, and prevention.
 
 </div>
 </li>

--- a/pages/health-care/index.md
+++ b/pages/health-care/index.md
@@ -21,7 +21,7 @@ crosslinks:
       description: Learn how to file a claim for disability compensation and manage your disability benefits.
     - url: "/life-insurance/"
       title: <strong>Life Insurance</strong>
-      description: Explore your life insurance options and find out how to apply as a Servicemember, Veteran, or family member.
+      description: Explore your life insurance options and find out how to apply as a service member, Veteran, or family member.
     - url: "/pension/aid-attendance-housebound/"
       title: <strong>Aid and Attendance Benefits and Housebound Allowance</strong>
       description: Find out if you can get increased pension pay as a Veteran or surviving spouse who has disabilities.

--- a/pages/housing-assistance/disability-housing-grants.md
+++ b/pages/housing-assistance/disability-housing-grants.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Disability Housing Grants for Veterans
 display_title: Housing Grants
-description: Find out if you're eligible for disability housing grants for Veterans and Servicemembers with certain service-connected disabilities. We offer these grants to disabled Veterans and Servicemembers who want to buy or change a home (like adding a ramp) to meet their needs and live more independently. 
+description: Find out if you're eligible for disability housing grants for Veterans and service members with certain service-connected disabilities. We offer these grants to disabled Veterans and service members who want to buy or change a home (like adding a ramp) to meet their needs and live more independently. 
 children: housingAssistanceDisabilityHousingGrants
 lastupdate:
 order: 2
@@ -15,7 +15,7 @@ concurrence:
 
 <div class="va-introtext">
 
-We offer grants to Veterans and Servicemembers with certain service-connected disabilities so they can buy or change a home to meet their needs and live more independently. Changing a home might involve installing ramps or widening doorways. Find out if you can get a grant to help meet your housing needs.
+We offer grants to Veterans and service members with certain service-connected disabilities so they can buy or change a home to meet their needs and live more independently. Changing a home might involve installing ramps or widening doorways. Find out if you can get a grant to help meet your housing needs.
 
 </div>
 
@@ -34,7 +34,7 @@ You may be able to get an SAH grant if you’re using the grant money to buy, bu
 - Certain severe burns
 - The loss or loss of use of one or both lower extremities (feet or legs) after September 11, 2001, that makes it so you can’t balance or walk without the help of braces, crutches, canes, or a wheelchair <br>
 
-**Please note:** We can only give this grant to 30 Veterans and Servicemembers each fiscal year (FY). We've already given out all of the available grants for FY 2019. If you qualify for but don't receive a grant in 2019 because the cap was reached, you may be able to use this benefit in FY 2020 or future years if the law continues to give us the authority to offer these grants and we don't go beyond the new FY cap.
+**Please note:** We can only give this grant to 30 Veterans and service members each fiscal year (FY). We've already given out all of the available grants for FY 2019. If you qualify for but don't receive a grant in 2019 because the cap was reached, you may be able to use this benefit in FY 2020 or future years if the law continues to give us the authority to offer these grants and we don't go beyond the new FY cap.
 
 For FY 2019, you may be able to get up to 3 grants—for a total of up to $85,645—through the SAH grant program.
 

--- a/pages/housing-assistance/home-loans.md
+++ b/pages/housing-assistance/home-loans.md
@@ -1,9 +1,9 @@
 ---
 layout: page-breadcrumbs.html
 template: detail-page
-title: Home Loans for Veterans, Servicemembers, and Survivors
+title: Home Loans for Veterans, Service Members, and Survivors
 display_title: VA-Backed Home Loans
-description: Find out if you're eligible and how to apply for VA direct and VA-backed home loans for Veterans, Servicemembers, and survivors. You may be eligible for loan programs to help you buy, build, repair, or refinance a home.
+description: Find out if you're eligible and how to apply for VA direct and VA-backed home loans for Veterans, service members, and survivors. You may be eligible for loan programs to help you buy, build, repair, or refinance a home.
 concurrence:
 children: housingHomeLoans
 spoke: VA Home Loans

--- a/pages/housing-assistance/home-loans/how-to-apply.md
+++ b/pages/housing-assistance/home-loans/how-to-apply.md
@@ -47,10 +47,10 @@ If you’re a **Veteran**, you’ll need a copy of your discharge or separation 
 </div>
 </li>
 <li>
-<button class="usa-button-unstyled usa-accordion-button" aria-controls="apply-coe-active-duty">Servicemember</button>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="apply-coe-active-duty">Service member</button>
 <div id="apply-coe-active-duty" class="usa-accordion-content">
 
-If you’re an **active-duty Servicemember**, you’ll need:
+If you’re an **active-duty service member**, you’ll need:
 
 * A statement of service—signed by your commander, adjutant, or personnel officer—showing this information:
   * Your full name

--- a/pages/housing-assistance/index.md
+++ b/pages/housing-assistance/index.md
@@ -27,7 +27,7 @@ crosslinks:
       description: If your service-connected disability limits your ability to work or prevents you from working, find out if you can get VR&E benefits and services—like help exploring employment options and getting more training if required.
     - url: /life-insurance/
       title: <b>Life Insurance</b>
-      description: Explore your life insurance options and find out how to apply as a Servicemember, Veteran, or family member.
+      description: Explore your life insurance options and find out how to apply as a service member, Veteran, or family member.
 social:
   - heading: Ask Questions
     subsections:
@@ -149,7 +149,7 @@ hublinks:
     links:
     - url: "/housing-assistance/disability-housing-grants/"
       label: About Disability Housing Grants for Veterans
-      description: Find out how to apply for a housing grant as a Veteran or Servicemember
+      description: Find out how to apply for a housing grant as a Veteran or service member
         with a service-connected disability.
       external: false
     - url: "/housing-assistance/disability-housing-grants/how-to-apply/"
@@ -164,7 +164,7 @@ hublinks:
       external: false
 ---
 <p class="va-introtext">
-VA housing assistance can help Servicemembers, Veterans, and their surviving spouses to buy a home or refinance a loan. We also offer benefits and services to help you build, repair, or keep your current home. This includes grants for Veterans with service-connected disabilities who need to adapt their home to live as independently as possible. Find out how to apply for and manage the Veterans housing assistance benefits you've earned.</p>
+VA housing assistance can help service members, Veterans, and their surviving spouses to buy a home or refinance a loan. We also offer benefits and services to help you build, repair, or keep your current home. This includes grants for Veterans with service-connected disabilities who need to adapt their home to live as independently as possible. Find out how to apply for and manage the Veterans housing assistance benefits you've earned.</p>
 
 <h3>On This Page</h3>
 <ul>

--- a/pages/index.md
+++ b/pages/index.md
@@ -3,7 +3,7 @@ layout: home.html
 body_class: home
 title: Home
 plainlanguage:
-description: Apply for and manage the VA benefits and services you’ve earned as a Veteran, Servicemember, or family member—like health care, disability, education, and more.
+description: Apply for and manage the VA benefits and services you’ve earned as a Veteran, service member, or family member—like health care, disability, education, and more.
 heading: Access and manage your VA benefits and health care
 aliases:
   - /families-caregivers/

--- a/pages/life-insurance/index.md
+++ b/pages/life-insurance/index.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: level2-index
 title: VA Life Insurance
 display_title: Life Insurance
-description: Explore VA life insurance options for Veterans, Servicemembers, and families. Manage your Veterans life insurance policy online, file claims for benefits, and access helpful resources.
+description: Explore VA life insurance options for Veterans, service members, and families. Manage your Veterans life insurance policy online, file claims for benefits, and access helpful resources.
 concurrence: complete
 lastupdate:
 order: 1
@@ -13,7 +13,7 @@ promo:
     alt:
     heading: SGLI Online Enrollment System (SOES)
     url: "https://www.benefits.va.gov/INSURANCE/SOES.asp"
-    description: Learn about our new online enrollment system for Servicemembers' Group Life Insurance.
+    description: Learn about our new online enrollment system for service members' Group Life Insurance.
 
 crosslinks:
   - heading: Other VA Benefits and Services
@@ -139,7 +139,7 @@ hublinks:
       external: false
     - url: https://www.benefits.va.gov/INSURANCE/SOES.asp
       label: About the SGLI Online Enrollment System (SOES)
-      description: Learn about our new online process for enrolling in Servicemembers' Group Life Insurance.
+      description: Learn about our new online process for enrolling in service members' Group Life Insurance.
       external: false
     - url: https://www.benefits.va.gov/INSURANCE/resources-contact.asp
       label: Contact Us
@@ -167,7 +167,7 @@ hublinks:
       external: false
 ---
 <p class="va-introtext">
-VA life insurance can offer financial security and support for Veterans, Servicemembers, their spouses and dependent children. Explore your options, manage your policy, and file claims to get the insurance benefits you've earned.</p>
+VA life insurance can offer financial security and support for Veterans, service members, their spouses and dependent children. Explore your options, manage your policy, and file claims to get the insurance benefits you've earned.</p>
 
 <h3>On This Page</h3>
 

--- a/pages/life-insurance/manage-your-policy.md
+++ b/pages/life-insurance/manage-your-policy.md
@@ -26,5 +26,5 @@ If you have VA life insurance, the easiest way to manage your policy is online. 
 If you have a VA life insurance policy with a file number that starts with a V, RH, J, RS, K, or W—or if you’d like to apply for service-disabled life insurance (life insurance for Veterans who have become disabled as a result of serving in the military), access your policy online through VA. <br>
 [Find your policy through VA](https://insurance.va.gov/home/). 
 
-If you have a Veterans’ Group Life Insurance (VGLI) policy with a VGLI control number, access your policy online through the Office of Servicemembers’ Group Life Insurance at Prudential Insurance Company of America. Prudential works with us to provide SGLI and VGLI benefits to Servicemembers and Veterans. <br>
+If you have a Veterans’ Group Life Insurance (VGLI) policy with a VGLI control number, access your policy online through the Office of Servicemembers’ Group Life Insurance at Prudential Insurance Company of America. Prudential works with us to provide SGLI and VGLI benefits to service members and Veterans. <br>
 <a href="https://giosgli.prudential.com/osgli/web/OSGLIMenu.html" data-popup>Find your policy through Prudential Insurance Company of America</a>.

--- a/pages/life-insurance/options-eligibility.md
+++ b/pages/life-insurance/options-eligibility.md
@@ -2,7 +2,7 @@
 layout: page-breadcrumbs.html
 title: About VA Insurance Options and Eligibility
 display_title: Options and Eligibility
-description: If you're a Veteran, Servicemember, or the spouse or dependent child of a Servicemember, find out which VA life insurance program may be right for you. If you're ending your active-duty service, in some cases you must act within 120 days of leaving the military to ensure no lapse in coverage.
+description: If you're a Veteran, service member, or the spouse or dependent child of a service member, find out which VA life insurance program may be right for you. If you're ending your active-duty service, in some cases you must act within 120 days of leaving the military to ensure no lapse in coverage.
 concurrence:
 template: detail-page
 no_article_bottom_padding: true
@@ -45,7 +45,7 @@ aliases:
 
 <div class="va-introtext">
 
-Are you a Servicemember, Veteran, or spouse or dependent child of a Servicemember? Find out which life insurance programs may be right for you.
+Are you a service member, Veteran, or spouse or dependent child of a service member? Find out which life insurance programs may be right for you.
 
 </div>
 

--- a/pages/life-insurance/options-eligibility/fsgli.md
+++ b/pages/life-insurance/options-eligibility/fsgli.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Family Servicemembers’ Group Life Insurance (FSGLI)
 display_title: Family Servicemembers’ Group (FSGLI)
-concurrence: 
+concurrence:
 order: 2
 relatedlinks:
   - heading: More information about your benefits
@@ -20,7 +20,7 @@ aliases:
 
 <div class="va-introtext">
 
-Are you the spouse or dependent child of a Servicemember who’s covered under Servicemembers’ Group Life Insurance (SGLI)? If you are, you may qualify for term life insurance coverage through Family Servicemembers’ Group Life Insurance (FSGLI). Find out if you qualify—and how to manage your coverage.
+Are you the spouse or dependent child of a service member who’s covered under Servicemembers’ Group Life Insurance (SGLI)? If you are, you may qualify for term life insurance coverage through Family Servicemembers’ Group Life Insurance (FSGLI). Find out if you qualify—and how to manage your coverage.
 
 </div>
 
@@ -30,11 +30,11 @@ Are you the spouse or dependent child of a Servicemember who’s covered under S
 
 ### Can I get FSGLI?
 
-You may be able to get FSGLI if you’re the spouse or dependent child of a Servicemember who meets one of the requirements listed below.
+You may be able to get FSGLI if you’re the spouse or dependent child of a service member who meets one of the requirements listed below.
 
-**One of these must be true. The Servicemember is:**
+**One of these must be true. The service member is:**
 
-* An active-duty Servicemember covered by full-time SGLI, **or**
+* An active-duty service member covered by full-time SGLI, **or**
 * A member of the National Guard or Ready Reserve covered by full-time SGLI
 
 You may qualify to get FSGLI as the spouse of someone with SGLI coverage no matter if your own status is active duty, retired, or civilian.
@@ -43,8 +43,8 @@ You may qualify to get FSGLI as the spouse of someone with SGLI coverage no matt
 
 #### Who’s covered?
 
-* Spouses of Servicemembers covered under SGLI
-* Dependent children of Servicemembers covered under SGLI
+* Spouses of service members covered under SGLI
+* Dependent children of service members covered under SGLI
 
 </div>
 
@@ -52,54 +52,54 @@ You may qualify to get FSGLI as the spouse of someone with SGLI coverage no matt
 
 ### What kind of life insurance benefits can I get with FSGLI?
 
-Up to a maximum of $100,000 of coverage for you as a spouse, not to exceed your Servicemember’s SGLI coverage, and $10,000 for each dependent child. Dependent children get free coverage.
+Up to a maximum of $100,000 of coverage for you as a spouse, not to exceed your service member’s SGLI coverage, and $10,000 for each dependent child. Dependent children get free coverage.
 
 <br>
 
 ### How do I get these benefits?
 
-#### If you’re the civilian spouse of a Servicemember signed up for full-time SGLI
+#### If you’re the civilian spouse of a service member signed up for full-time SGLI
 
-We’ll automatically insure you under FSGLI. In this case, we’ll automatically take your premium out of your Servicemember’s pay.
+We’ll automatically insure you under FSGLI. In this case, we’ll automatically take your premium out of your service member’s pay.
 
 #### If you’re a military spouse and you were married on or after January 2, 2013
 
-We won’t automatically cover you. You’ll need to sign up through your Servicemember.
+We won’t automatically cover you. You’ll need to sign up through your service member.
 
-**If your Servicemember’s branch of service has started using the new SGLI Online Enrollment System (SOES),** have your Servicemember sign you up online. 
+**If your service member’s branch of service has started using the new SGLI Online Enrollment System (SOES),** have your service member sign you up online.
 
-To access SOES, have your Servicemember:
+To access SOES, have your service member:
 
 <ol class="process" markdown="1">
 
   <li class="process-step list-one">
-  
+
   [Go to milConnect](https://www.dmdc.osd.mil/milconnect/).
-  
+
   </li>
-  
+
   <li class="process-step list-two">
-  
+
   Sign in.
-  
+
   </li>
   <li class="process-step list-three">
-  
+
   Go to Benefits, Life Insurance SOES- SGLI Online Enrollment System to sign up.
-  
+
   </li>
 </ol>
 
-Your Servicemember can log in with their CAC or DS Logon using Internet Explorer as soon as they receive notice that they can start using SOES.
+Your service member can log in with their CAC or DS Logon using Internet Explorer as soon as they receive notice that they can start using SOES.
 
-**If your Servicemember’s branch of service hasn’t yet started using SOES,** fill out the Spouse Coverage Election and Certificate and have your Servicemember turn it in to the personnel office for their unit. <br>
+**If your service member’s branch of service hasn’t yet started using SOES,** fill out the Spouse Coverage Election and Certificate and have your service member turn it in to the personnel office for their unit. <br>
 [Download the Spouse Coverage Election and Certificate](https://www.benefits.va.gov/INSURANCE/forms/SGLV_8286A_ed2017-10.PDF).
 
 <br>
 
-### How much will my Servicemember pay for spousal coverage—and how do the premium payments work?
+### How much will my service member pay for spousal coverage—and how do the premium payments work?
 
-Your Servicemember will pay a premium for your coverage, which will increase as you age. Choose your age below to view current spousal coverage monthly premium rates based on the amount of insurance coverage you want.
+Your service member will pay a premium for your coverage, which will increase as you age. Choose your age below to view current spousal coverage monthly premium rates based on the amount of insurance coverage you want.
 
 <ul class="usa-accordion" aria-multiselectable="true">
 <li>
@@ -237,47 +237,47 @@ Your Servicemember will pay a premium for your coverage, which will increase as 
 </li>
 </ul>
 
-If you’re signed up as a spouse in the Defense Enrollment Eligibility Reporting System (DEERS), we’ll automatically deduct the FSGLI premium from your Servicemember’s pay. If you aren’t signed up in DEERS, your Servicemember will still be responsible for premiums and back payments of unpaid premiums.
+If you’re signed up as a spouse in the Defense Enrollment Eligibility Reporting System (DEERS), we’ll automatically deduct the FSGLI premium from your service member’s pay. If you aren’t signed up in DEERS, your service member will still be responsible for premiums and back payments of unpaid premiums.
 
 <br>
 
-### Can my Servicemember make changes to my coverage?
+### Can my service member make changes to my coverage?
 
 Yes. If you have spousal coverage and you want to reduce, turn down, or cancel it:
 
-**If your Servicemember’s branch of service has started using the new SGLI Online Enrollment System (SOES),** have your Servicemember submit your changes online.
+**If your service member’s branch of service has started using the new SGLI Online Enrollment System (SOES),** have your service member submit your changes online.
 
-To access SOES, have your Servicemember:
+To access SOES, have your service member:
 
 <ol class="process" markdown="1">
 
   <li class="process-step list-one">
-  
+
   [Go to milConnect](https://www.dmdc.osd.mil/milconnect/).
-  
+
   </li>
-  
+
   <li class="process-step list-two">
-  
+
   Sign in.
-  
+
   </li>
   <li class="process-step list-three">
-  
+
   Go to Benefits, Life Insurance SOES- SGLI Online Enrollment System to update.
-  
+
   </li>
-  
+
   <li class="process-step list-four">
-  
+
   Check their coverage and beneficiary info and make any needed updates.
-  
+
   </li>
  </ol>
 
-Your Servicemember can log in with their CAC or DS Logon using Internet Explorer as soon as they receive notice that they can start using SOES.
+Your service member can log in with their CAC or DS Logon using Internet Explorer as soon as they receive notice that they can start using SOES.
 
-**If your Servicemember’s branch of service hasn’t yet started using SOES,** fill out the Spouse Coverage Election and Certificate and have your Servicemember turn it in to the personnel office for their unit. <br>
+**If your service member’s branch of service hasn’t yet started using SOES,** fill out the Spouse Coverage Election and Certificate and have your service member turn it in to the personnel office for their unit. <br>
 [Download the Spouse Coverage Election and Certificate](https://www.benefits.va.gov/INSURANCE/forms/SGLV_8286A_ed2017-10.PDF).
 <br>
 [Learn more about SOES and find out if your branch is using this new system](https://www.benefits.va.gov/INSURANCE/SOES.asp).
@@ -286,18 +286,18 @@ Your Servicemember can log in with their CAC or DS Logon using Internet Explorer
 
 <br>
 
-### How much will my Servicemember pay for dependent coverage?
+### How much will my service member pay for dependent coverage?
 
 Nothing. We provide dependent coverage at no cost until the child is 18 years old, or sometimes longer if the child meets one of the requirements listed below.
 
 **To continue receiving dependent coverage after age 18, one of these must be true. The child**:
 - Is a full-time student, **or**
-- Becomes permanently and totally disabled—before turning 18—and can’t support themselves 
+- Becomes permanently and totally disabled—before turning 18—and can’t support themselves
 
 
 <br>
 
-### Can my Servicemember get extended coverage for our dependent child?
+### Can my service member get extended coverage for our dependent child?
 
 Yes, in some cases. Coverage lasts until the child is 18 years old. But, if the child is a full-time student between 18 and 22 years old, we may extend the coverage. Or, if the child becomes permanently and totally disabled before turning 18 and is no longer able to support themselves, we may extend the coverage—in some cases indefinitely.
 
@@ -305,7 +305,7 @@ Yes, in some cases. Coverage lasts until the child is 18 years old. But, if the 
 
 ### How do I convert a spousal FSGLI policy to an individual insurance policy?
 
-You have the option to convert spousal FSGLI coverage to a permanent, individual insurance policy (such as whole life) within 120 days from the date of your Servicemember’s:
+You have the option to convert spousal FSGLI coverage to a permanent, individual insurance policy (such as whole life) within 120 days from the date of your service member’s:
 
 * Separation from the military
 * Divorce from you
@@ -313,7 +313,7 @@ You have the option to convert spousal FSGLI coverage to a permanent, individual
 * Written election to end their SGLI coverage
 * Death
 
-If any of the above events happen, you, as the Servicemember’s spouse, become solely responsible for all aspects of the policy, including premium payments.
+If any of the above events happen, you, as the service member’s spouse, become solely responsible for all aspects of the policy, including premium payments.
 
 You can’t convert other types of policies—such as term, variable, or universal life insurance. And, supplementary policy benefits—such as accidental death and dismemberment or a waiver of the premium for disability—aren’t considered part of the conversion policy.
 
@@ -323,11 +323,11 @@ You can’t convert other types of policies—such as term, variable, or univers
 [View the companies you can choose from](https://www.benefits.va.gov/INSURANCE/forms/ParticList.htm).
 - Apply at the local sales office of the company you chose.
 - Give a copy of the most recent Leave and Earnings Statement (LES) to the agent, showing the deduction for spousal SGLI. You’ll also have to provide proof of coverage with one of these documents:
-  - The Servicemember’s separation document (Form DD214 or NGB-22, or written orders)
-  - The Certificate of Dissolution of Marriage between the spouse and the Servicemember
-  - The Servicemember’s FSGLI spousal declination
-  - The Servicemember’s SGLI declination
-  - The Servicemember’s proof of death (DD1300: Report of Casualty, or a civilian death certificate)
+  - The service member’s separation document (Form DD214 or NGB-22, or written orders)
+  - The Certificate of Dissolution of Marriage between the spouse and the service member
+  - The service member’s FSGLI spousal declination
+  - The service member’s SGLI declination
+  - The service member’s proof of death (DD1300: Report of Casualty, or a civilian death certificate)
 
 
 <br>

--- a/pages/life-insurance/options-eligibility/sgli.md
+++ b/pages/life-insurance/options-eligibility/sgli.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Servicemembers’ Group Life Insurance (SGLI)
 display_title: Servicemembers’ Group (SGLI)
-concurrence: 
+concurrence:
 order: 1
 relatedlinks:
   - heading: More information about your benefits
@@ -33,7 +33,7 @@ If you’re a service member who meets certain criteria, we’ll automatically s
 
 <div class="feature">
 
-### Can I get SGLI? 
+### Can I get SGLI?
 
 You may be able to get full-time SGLI coverage if any of the descriptions below are true for you.
 
@@ -79,7 +79,7 @@ If you qualify for SGLI, we’ll automatically sign you up through your service 
 
 <br>
 
-### Can I make changes to my benefits? 
+### Can I make changes to my benefits?
 
 Yes. You can choose your level of coverage or even refuse coverage completely. You can also choose your beneficiaries (the people you pick to get the money from your life insurance policy if you die) and change them as needed.
 
@@ -89,31 +89,31 @@ Yes. You can choose your level of coverage or even refuse coverage completely. Y
 
 <ol class="process" markdown="1">
   <li class="process-step list-one">
-  
+
   [Go to milConnect](https://www.dmdc.osd.mil/milconnect/).
-  
+
   </li>
-  
+
   <li class="process-step list-two">
-  
+
   Sign in.
-  
+
   </li>
-  
+
   <li class="process-step list-three">
-  
+
   Go to Benefits, Life Insurance SOES-SGLI Online Enrollment System.
-  
+
   </li>
-  
+
   <li class="process-step list-four">
-  
+
   Check your coverage and beneficiary information and make any needed updates.
-  
+
  </li>
  </ol>
 
-You can log in with your CAC or DS Logon using Internet Explorer as soon as you receive a notice that you can start using SOES. 
+You can log in with your CAC or DS Logon using Internet Explorer as soon as you receive a notice that you can start using SOES.
 
 <br>
 
@@ -146,7 +146,7 @@ If you have SGLI coverage, you’ll pay a monthly premium that’ll be automatic
 <span id="convert"></a>
 ## Converting SGLI when you separate or retire
 
-### How do I convert my SGLI when I leave the military? 
+### How do I convert my SGLI when I leave the military?
 When you leave the military, you can apply to convert to Veterans’ Group Life Insurance (VGLI) within 1 year and 120 days from your discharge for up to the amount of coverage you had through SGLI. <br>
 [Learn more about VGLI](/life-insurance/options-eligibility/vgli/).
 
@@ -157,7 +157,7 @@ You can also convert your SGLI policy into a civilian policy within 120 days fro
 
 <span id="extension"></span>
 
-### Can I get a free extension of my SGLI coverage if I’m disabled when I leave the military? 
+### Can I get a free extension of my SGLI coverage if I’m disabled when I leave the military?
 You may be able to keep your coverage for up to 2 years after the date you left the military if you’re within 2 years of your separation date and you meet either of the requirements listed below.
 
 **At least one of these must be true:**
@@ -170,9 +170,9 @@ You may be able to keep your coverage for up to 2 years after the date you left 
 
 <br>
 
-### How do I apply for SGLI Disability Extension? 
+### How do I apply for SGLI Disability Extension?
 
-You’ll need to apply for the Servicemembers’ Group Life Insurance Disability Extension (SGLI-DE). 
+You’ll need to apply for the Servicemembers’ Group Life Insurance Disability Extension (SGLI-DE).
 
 To apply, fill out the SGLI Disability Extension Application and send it to the OSGLI address listed on the application. <br>
 [Download the SGLI Disability Extension Application](https://www.benefits.va.gov/INSURANCE/forms/SGLV_8715_ed2017-09.pdf).

--- a/pages/life-insurance/options-eligibility/tsgli.md
+++ b/pages/life-insurance/options-eligibility/tsgli.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Traumatic Injury Protection (TSGLI)
 display_title: Traumatic Injury Protection (TSGLI)
-concurrence: 
+concurrence:
 order: 3
 children: lifeInsuranceTSGLI
 relatedlinks:
@@ -24,7 +24,7 @@ Did you suffer a traumatic injury while serving in the military? Our Servicememb
 
 <div class="feature">
 
-### Can I get TSGLI? 
+### Can I get TSGLI?
 
 You may be able to get TSGLI if you were insured by SGLI when you experienced a traumatic injury, and you meet all of the requirements listed below.
 
@@ -38,7 +38,7 @@ You may be able to get TSGLI if you were insured by SGLI when you experienced a 
 
 <br>
 
-#### Are any injuries excluded from TSGLI? 
+#### Are any injuries excluded from TSGLI?
 
 Yes. To qualify for TSGLI, none of the descriptions below can be true of your injury.
 
@@ -58,16 +58,16 @@ Yes. To qualify for TSGLI, none of the descriptions below can be true of your in
 
 You may be able to get retroactive TSGLI (meaning that it takes effect starting from a date in the past) if you were injured between October 7, 2001, and November 30, 2005, and you meet all of the TSGLI qualifications listed above.
 
-You can use this benefit no matter where the injury happened—whether you were on or off duty—and no matter if your SGLI coverage was in effect when you got injured. 
+You can use this benefit no matter where the injury happened—whether you were on or off duty—and no matter if your SGLI coverage was in effect when you got injured.
 
 **Note:** We’ve removed the previous requirement that you must have been injured during Operations Enduring or Iraqi Freedom (OEF or OIF). <br>
-[Find out if you qualify for retroactive benefits](https://www.benefits.va.gov/insurance/tsgli-claim-questionnaire.asp). 
+[Find out if you qualify for retroactive benefits](https://www.benefits.va.gov/insurance/tsgli-claim-questionnaire.asp).
 
 <br>
 
 #### Who’s covered?
 
-Servicemembers covered by SGLI
+Service members covered by SGLI
 
 </div>
 
@@ -95,11 +95,11 @@ First, look at the denial letter you received from your branch of service. Your 
 
 If your letter says to complete this form, fill it out and submit it to your branch of service.<br>
 
-[Download the TSGLI Appeal Request Form](https://benefits.va.gov/INSURANCE/forms/SGLV_8600A_ed2017-01.pdf). 
+[Download the TSGLI Appeal Request Form](https://benefits.va.gov/INSURANCE/forms/SGLV_8600A_ed2017-01.pdf).
 
 <br>
 
-### How much will I pay for these benefits? 
+### How much will I pay for these benefits?
 
 If you have SGLI coverage, your SGLI premium (which is automatically deducted from your base pay) includes a $1-per-month flat-rate premium for TSGLI. This is all you’ll pay for this benefit.
 
@@ -108,4 +108,3 @@ If you have SGLI coverage, your SGLI premium (which is automatically deducted fr
 ### Where can I find more information?
 
 [Read our insurance publications](https://www.benefits.va.gov/INSURANCE/ins_publications.asp).
-

--- a/pages/life-insurance/options-eligibility/vgli.md
+++ b/pages/life-insurance/options-eligibility/vgli.md
@@ -44,7 +44,7 @@ You may be able to get VGLI if you meet at least one of the requirements listed 
 #### Who’s covered?
 
 * Veterans
-* Former Servicemembers
+* Former service members
 
 </div>
 
@@ -64,7 +64,7 @@ You’ll need to apply for these benefits. When you apply, you won’t need to p
 
 **Apply in one of these ways:**
 
-- Apply through the Office of Servicemembers' Group Life Insurance (OSGLI), using the Prudential website. <br>
+- Apply through the Office of service members' Group Life Insurance (OSGLI), using the Prudential website. <br>
 [Apply online through OSGLI](https://giosgli.prudential.com/osgli/OnlineFillableAppController/NBEnrollment).
 - [Apply online through eBenefits](https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vgli-policy-management).
 - Apply by mail or fax. Fill out the Application for Veterans’ Group Life Insurance. <br>

--- a/pages/life-insurance/options-eligibility/vmli.md
+++ b/pages/life-insurance/options-eligibility/vmli.md
@@ -23,7 +23,7 @@ If you have a severe service-connected disability that we’ve concluded was cau
 
 <div class="feature">
 
-### Can I get VMLI? 
+### Can I get VMLI?
 
 You may be able to get VMLI if you have a severe disability, and you meet all of the requirements listed below.
 
@@ -40,7 +40,7 @@ You may be able to get VMLI if you have a severe disability, and you meet all of
 
 #### Who’s covered?
 
-- Servicemembers
+- Service members
 - Veterans
 
 </div>
@@ -49,13 +49,13 @@ You may be able to get VMLI if you have a severe disability, and you meet all of
 
 ### What kind of life insurance benefits can I get with VMLI?
 
-Up to $200,000 in mortgage life insurance—paid directly to the bank or other lender that holds your mortgage. 
+Up to $200,000 in mortgage life insurance—paid directly to the bank or other lender that holds your mortgage.
 
 #### Important details about VMLI:
 
 - The money will be paid directly to the bank or other lender that holds your mortgage—not to a life insurance beneficiary (a person chosen to receive the money from a policy when the insured dies).
-- The amount of coverage will equal the amount you still owe on your mortgage, but won’t be more than $200,000. 
-- VMLI is a decreasing-term insurance. This means your coverage amount goes down as your mortgage balance goes down. If you pay off your mortgage, your VMLI coverage will end. 
+- The amount of coverage will equal the amount you still owe on your mortgage, but won’t be more than $200,000.
+- VMLI is a decreasing-term insurance. This means your coverage amount goes down as your mortgage balance goes down. If you pay off your mortgage, your VMLI coverage will end.
 - VMLI has no loan or cash value—and it doesn’t pay dividends (cash payments made to policy holders when the company makes a profit).
 
 <br>
@@ -65,7 +65,7 @@ Up to $200,000 in mortgage life insurance—paid directly to the bank or other l
 First, you’ll need to apply for an SAH grant. If you get the SAH grant, your Loan Guaranty agent will tell you if you qualify for VMLI. If you already have an SAH grant, ask your agent about VMLI.
 
 Your agent will help you fill out a Veterans’ Mortgage Life Insurance Statement (VA Form 29-8636).<br>
-[Download VA Form 29-8636](https://www.benefits.va.gov/INSURANCE/forms/29-8636_08-2011.pdf). 
+[Download VA Form 29-8636](https://www.benefits.va.gov/INSURANCE/forms/29-8636_08-2011.pdf).
 
 **Note:** Remember, you must apply for VMLI before your 70th birthday.
 
@@ -105,4 +105,4 @@ Send notice of any changes to:
   Philadelphia, PA 19101<br>
 </p>
 
-[Read our life insurance publications for more guidance](https://www.benefits.va.gov/INSURANCE/ins_publications.asp). 
+[Read our life insurance publications for more guidance](https://www.benefits.va.gov/INSURANCE/ins_publications.asp).

--- a/pages/life-insurance/totally-disabled-or-terminally-ill.md
+++ b/pages/life-insurance/totally-disabled-or-terminally-ill.md
@@ -24,7 +24,7 @@ If you become totally disabled or terminally ill, you may be able to get certain
 
 <hr>
 
-### Extension of Servicemembers' Group Life Insurance (SGLI) for policyholders who become disabled
+### Extension of service members' Group Life Insurance (SGLI) for policyholders who become disabled
 
 <br>
 
@@ -107,8 +107,8 @@ You or your spouse may be able to get benefits early if you meet both of the req
 ##### Who’s covered?
 
 -	Veterans
--	Servicemembers
--	Covered spouses of Servicemembers
+-	service members
+-	Covered spouses of service members
 
 </div>
 
@@ -122,7 +122,7 @@ Up to 50% of the face value of your coverage in increments of $5,000—paid to y
 
 #### How do we get these benefits?
  
-Only the insured Servicemember or Veteran may apply for accelerated benefits. No one may apply on their behalf. In the case of a terminally ill spouse, only the insured may apply. 
+Only the insured service member or Veteran may apply for accelerated benefits. No one may apply on their behalf. In the case of a terminally ill spouse, only the insured may apply. 
 
 **Use the application form for the type of coverage you have:**
  
@@ -154,7 +154,7 @@ We pay the remaining amount of the face value of the insurance policy to your de
  
 #### Where can I find more information?
  	
-[Read chapter 5 of the Servicemembers’ and Veterans’ Group Life Insurance Handbook](https://benefits.va.gov/INSURANCE/resources_handbook_ins_chapter5.asp).
+[Read chapter 5 of the service members’ and Veterans’ Group Life Insurance Handbook](https://benefits.va.gov/INSURANCE/resources_handbook_ins_chapter5.asp).
 
-[Contact the Office of Servicemembers' Group Life Insurance (OSGLI)](https://benefits.va.gov/INSURANCE/resources-contact.asp).
+[Contact the Office of service members' Group Life Insurance (OSGLI)](https://benefits.va.gov/INSURANCE/resources-contact.asp).
 

--- a/pages/pension/index.md
+++ b/pages/pension/index.md
@@ -20,13 +20,13 @@ crosslinks:
       description: Find out how to apply for and manage your VA health care benefits.
     - url: /housing-assistance/disability-housing-grants/
       title: <b>Disability Housing Grants for Veterans</b>
-      description: Learn how to apply for a housing grant as a Veteran or Servicemember with a service-connected disability.
+      description: Learn how to apply for a housing grant as a Veteran or service member with a service-connected disability.
     - url:  /careers-employment/vocational-rehabilitation/
       title: <b>Vocational Rehabilitation and Employment</b>
       description: Find out if you qualify for help exploring employment options, any training you may need, and other voc rehab services.
     - url: /life-insurance/
       title: <b>Life Insurance</b>
-      description: Explore your life insurance options and find out how to apply as a Servicemember, Veteran, or family member.
+      description: Explore your life insurance options and find out how to apply as a service member, Veteran, or family member.
 social:
   - heading: Ask Questions
     subsections:

--- a/pages/sign-in-faq.md
+++ b/pages/sign-in-faq.md
@@ -194,7 +194,7 @@ display_title: Frequently Asked Questions
                         <p>Follow these 2 steps to sign up for a Premium <strong>DS Logon</strong> account.</p>
                         <p><strong>1. First, make sure you’re enrolled in the Defense Enrollment Eligibility Reporting System (DEERS).</strong> This is the database that records all the people who are eligible for military benefits.</p>
                         <ul>
-                          <li><strong>If you’re a Veteran or Servicemember or qualified family caregiver, survivor, or dependent of a Veteran or Servicemember who served after 1982,</strong> you should already be enrolled in DEERS.</li>
+                          <li><strong>If you’re a Veteran or service member or qualified family caregiver, survivor, or dependent of a Veteran or service member who served after 1982,</strong> you should already be enrolled in DEERS.</li>
                           <li><strong>If you’re a Veteran or the qualified family caregiver, survivor, or dependent of a Veteran who served before 1982,</strong> you may not be enrolled. To enroll, call us at <a href="tel:+1phonenumber">1-800-827-1000</a> and choose “Option 7.” Tell the operator you want to enroll in DEERS, and ask them to send you an email confirming when enrollment is complete.</li>
                         </ul>
                         <p><strong>2. Then, register for your basic DS Logon account online.</strong></p>

--- a/pages/va-payment-history.md
+++ b/pages/va-payment-history.md
@@ -38,7 +38,7 @@ Find out how to view your payment history for VA benefits.
 <li>Education benefits</li>
 </ul>
 
-<b>If you're the survivor of a Veteran or Servicemember, you'll see a history of your past payments for:</b>
+<b>If you're the survivor of a Veteran or service member, you'll see a history of your past payments for:</b>
 <ul>
 <li>Survivors pension benefits</li>
 <li>Survivors' and Dependents' Educational Assistance (Chapter 35 benefits)</li>

--- a/pages/welcome-kit.md
+++ b/pages/welcome-kit.md
@@ -25,7 +25,7 @@ majorlinks:
         description: Apply for vocational rehabilitation services, get support for your Veteran-owned small business, and access other career resources.
       - url: /life-insurance/
         title: Life Insurance
-        description: Explore VA life insurance options for Veterans, Servicemembers, and families. Manage your policy online, file claims for benefits, and access helpful resources.
+        description: Explore VA life insurance options for Veterans, service members, and families. Manage your policy online, file claims for benefits, and access helpful resources.
       - url: /pension/
         title: Pension
         description: Apply for monthly payments for wartime Veterans and survivors with limited or no income who meet certain age and disability requirements.
@@ -37,7 +37,7 @@ majorlinks:
         description: Apply for a printed Veteran ID card, get your VA benefit letters and medical records, and learn how to apply for a discharge upgrade.
       - url: #
         title: Family and Caregiver Benefits
-        description: Learn about benefits for spouses and dependents of a Veteran or Servicemember, including added support if you're caring for a Veteran with a service-connected disability.
+        description: Learn about benefits for spouses and dependents of a Veteran or service member, including added support if you're caring for a Veteran with a service-connected disability.
 ---
 
 <div itemscope itemtype ="http://schema.org/HowTo">


### PR DESCRIPTION
Originally PR: https://github.com/department-of-veterans-affairs/vagov-content/pull/376

## Page to edit
url: many (75 files)

## Origin of request (internal/stakeholder/user feedback)
Style guide specifies lower case "service member" instead of Servicemember.

## Description of what's needed (edits/link changes/additions)

I left "Servicemember" intact--one word and capitlized--anytime it was part of a formal name like "Servicemembers' Group Life Insurance" and "Family Servicemembers’ Group Life Insurance". 

There are also some cases where Servicemember was the at the start of a line or bullet, so it's been changed to "Service member". 

## What's not included
Changing URLs and id's (anchor links) from servicemember to service-member. There are two places where this happens: 
1) links to the legacy page  https://www.va.gov/HEALTHBENEFITS/apply/returning_servicemembers.asp
2) links to an anchor link, eg `[Find out how to apply if you haven't yet received a disability rating](/careers-employment/vocational-rehabilitation/how-to-apply/#servicemember-not-received-rating).`