### PR TITLE
[Bug] Fix H1 on Privacy Page to Left-Aligned

### DIFF
--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -1,6 +1,6 @@
 ---
 layout: page-breadcrumbs.html
-template: level2-index
+template: detail-page
 title: Privacy, Policies, and Legal Information
 ---
 


### PR DESCRIPTION
## Page to edit
url: `/privacy/`

## Origin of request (internal/stakeholder/user feedback)
internal (@WinishaSmith 

## Description of what's needed (edits/link changes/additions)
The purpose of this PR is to adjust the `<h1>` at the top of the page to be left-aligned.

I accomplished this by changing the template from `leve2-index`. to `detail-page`.

**Before**:
![Screen Shot 2019-04-12 at 5 37 26 PM](https://user-images.githubusercontent.com/11021491/56067589-af816780-5d49-11e9-8056-2825828c5ef1.png)

**After**:
![Screen Shot 2019-04-12 at 5 33 04 PM](https://user-images.githubusercontent.com/11021491/56067555-94aef300-5d49-11e9-8409-0aa92ed8e604.png)

