### PR TITLE
Remove usa-alert-warning.background-color-only from inside accordion.

### DIFF
--- a/pages/pension/how-to-apply/fully-developed-claim.md
+++ b/pages/pension/how-to-apply/fully-developed-claim.md
@@ -139,15 +139,7 @@ With the standard claim process, we’ll handle the evidence-gathering steps lis
 
 You’ll need to turn in the information and evidence at the same time as you file your claim.
 
-<div class="usa-alert usa-alert-warning background-color-only">
-<div class="usa-alert-body">
-<div class="usa-alert-text">
-
 **Note:** If you turn in additional information or evidence after you send in your fully developed claim, we’ll remove your claim from the FDC program and process it as a standard claim. If we decide your claim before 1 year from the date we receive the claim, you’ll have the rest of that 1-year period to turn in additional information or evidence to support your claim.
-
-</div>
-</div>
-</div>
 
 <br>
 
@@ -155,15 +147,8 @@ You’ll need to turn in the information and evidence at the same time as you fi
 
 You’ll need to turn in the information and evidence as soon as you can.
 
-<div class="usa-alert usa-alert-warning background-color-only">
-<div class="usa-alert-body">
-<div class="usa-alert-text">
-
 **Note:** You have up to 1 year from the date we receive your claim to turn in any information and evidence. If we decide your claim before 1 year from the date we receive the claim, you’ll have the rest of the 1-year period to turn in additional information or evidence to support your claim.
 
-</div>
-</div>
-</div>
 </div>
 </li>
 


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/pension/how-to-apply/fully-developed-claim/

## Origin of request (internal/stakeholder/user feedback)
This is the only place in the repo where an alert with "background color only" is being used (`<div class="usa-alert usa-alert-warning background-color-only">`).  The CMS will not support this class, at least not for now. This commit removes these two. 

## Description of what's needed (edits/link changes/additions)
See screenshot.

![Fully_Developed_Claim_Program___Veterans_Affairs_and_Fully_Developed_Claim_Program___Veterans_Affairs_and_VA_Housing_Assistance___Veterans_Affairs](https://user-images.githubusercontent.com/643678/56403039-aef73e00-622d-11e9-9ad1-df01e8e6adcb.jpg)

