### PR TITLE
[MegaMenu] Fix for links not resolving properly on TeamSite pages

### DIFF
--- a/fragments/megamenu/index.yml
+++ b/fragments/megamenu/index.yml
@@ -271,10 +271,10 @@
         href: https://www.va.gov/records/
   - title: Service member benefits
     text: Service member benefits
-    href: /service-member-benefits/
+    href: https://www.va.gov/service-member-benefits/
   - title: Family member benefits
     text: Family member benefits
-    href: /family-member-benefits/
+    href: https://www.va.gov/family-member-benefits/
 - title: About VA
   menuSections:
     mainColumn:


### PR DESCRIPTION
The links to the Service Member hub and Family Member hub in the MegaMenu aren't resolving properly on TeamSite pages. They should have been absolute URLs instead of relative.  Example - https://www.benefits.va.gov/compensation/dbq_disabilityexams.asp.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18280