### PR TITLE
Remove rogue va-h-ruled--stars.

### DIFF
--- a/pages/decision-reviews/faq.md
+++ b/pages/decision-reviews/faq.md
@@ -19,10 +19,6 @@ Learn more about the review options and how to request a review. If you need hel
 - [What if I want to change my review option after submitting a form?](#change-review)
 
 
-<section class="usa-grid usa-grid-full">
-  <div class="va-h-ruled--stars"></div>
-</section>
-
 <div id="relevant-evidence">
 
 ## What’s new and relevant evidence?


### PR DESCRIPTION
<section class="usa-grid usa-grid-full">
  <div class="va-h-ruled--stars"></div>
</section>

## Page to edit
url: https://www.va.gov/decision-reviews/faq/

## Origin of request (internal/stakeholder/user feedback)

this is the only use of va-h-ruled--stars on a benefit detail page (they are used within benefits as a separator between spokes). @jenniferlee-dsva suggested this one is rogue. 

## Description of what's needed (edits/link changes/additions)

Remove hr