### PR TITLE
Remove two column layout for state listings on Pension Management page.

### DIFF
--- a/pages/pension/pension-management-centers.md
+++ b/pages/pension/pension-management-centers.md
@@ -18,9 +18,7 @@ We have 3 regional pension management centers. Look at the lists below to find t
 
 This office serves:
 
-<div class="usa-grid-full">
 
-<div class="small-12 medium-6 usa-width-five-twelfths columns">
 <ul>
 <li>Connecticut</li>
 <li>Delaware</li>
@@ -32,11 +30,6 @@ This office serves:
 <li>New Hampshire</li>
 <li>New Jersey</li>
 <li>New York</li>
-</ul>
-</div>
-
-<div class="small-12 medium-6 usa-width-five-twelfths columns">
-<ul>
 <li>North Carolina</li>
 <li>Pennsylvania</li>
 <li>Puerto Rico</li>
@@ -47,9 +40,6 @@ This office serves:
 <li>West Virginia</li>
 <li>All other foreign countries not included under the VA St. Paul Pension Management Center below
 </ul>
-</div>
-
-</div>
 
 To submit a pension application to this office, mail it to:
 
@@ -71,8 +61,6 @@ Or, fax it to 1-844-655-1604.
 
 This office serves:
 
-<div class="usa-grid-full">
-<div class="small-12 medium-6 usa-width-five-twelfths columns">
 <ul>
 <li>Alabama</li>
 <li>Arkansas</li>
@@ -80,11 +68,6 @@ This office serves:
 <li>Illinois</li>
 <li>Kentucky</li>
 <li>Louisiana</li>
-</ul>
-</div>
-
-<div class="small-12 medium-6 usa-width-five-twelfths columns">
-<ul>
 <li>Michigan</li>
 <li>Mississippi</li>
 <li>Missouri</li>
@@ -92,9 +75,7 @@ This office serves:
 <li>Tennessee</li>
 <li>Wisconsin</li>
 </ul>
-</div>
 
-</div>
 
 To submit a pension application to this office, mail it to:
 
@@ -116,9 +97,6 @@ Or, fax it to 1-844-655-1604.
 
 This office serves:
 
-<div class="usa-grid-full">
-
-<div class="small-12 medium-6 usa-width-five-twelfths columns">
 <ul>
 <li>Alaska</li>
 <li>Arizona</li>
@@ -133,11 +111,6 @@ This office serves:
 <li>Nebraska</li>
 <li>Nevada</li>
 <li>New Mexico</li>
-</ul>
-</div>
-
-<div class="small-12 medium-6 usa-width-five-twelfths columns">
-<ul>
 <li>North Dakota</li>
 <li>Oklahoma</li>
 <li>Oregon</li>
@@ -151,9 +124,6 @@ This office serves:
 <li>South America</li>
 <li>The Caribbean</li>
 </ul>
-</div>
-
-</div>
 
 To submit a pension application to this office, mail it to:
 


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/pension/pension-management-centers/

## Origin of request (internal/stakeholder/user feedback)
Content anomaly: CMS body fields will not support grid layouts.

## Description of what's needed (edits/link changes/additions)
Remove grid layout. 
