### PR TITLE
Make Education's "On this page" an <h3>, like other hubs.

### DIFF
--- a/pages/education/index.md
+++ b/pages/education/index.md
@@ -226,7 +226,7 @@ hublinks:
 VA education benefits help Veterans, service members, and their qualified family members with needs like paying college tuition, finding the right school or training program, and getting career counseling. Learn how to apply for and manage the education and training benefits you've earned.
 </p>
 
-<h2>On this page</h2>
+<h3>On this page</h3>
 
 <ul>
   <li><a href="#get">Get GI Bill and other education benefits</a></li>


### PR DESCRIPTION
## Page to edit
url: va.gov/education

## Origin of request (internal/stakeholder/user feedback)
"On this page" header is an `<h3>` for all hubs except education, where it was an `<h2>`.  This commit standardizes.

## Description of what's needed (edits/link changes/additions)
Replace `<h2>` with `<h3>`
