### PR TITLE
Add redirect for /decision-reviews/get-help

### DIFF
--- a/pages/decision-reviews/get-help.html
+++ b/pages/decision-reviews/get-help.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+<meta http-equiv=refresh content="0; url=https://www.va.gov/decision-reviews/get-help-with-review-request/">
+<link rel=canonical href="https://www.va.gov/decision-reviews/get-help-with-review-request/">
+<title>Page Moved</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
There is a server-side redirect for `/decision-reviews/get-help/`. However, we also need to capture the case without the trailing slash. We can't add that to the server without creating a redirect loop, because the server-side redirects are greedy and try to redirect any routes that match `/decision-review/get-help*`. There is a Devops ticket to change this but the work is ongoing, https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17486.

We can no longer add FE `aliases`, because the work migrating content into the CMS causes us to lose those values. So, we're at a tough spot, and just adding this here seems to be the only way we can do this.