### PR TITLE
Remove empty 'relatedlinks:' frontmatter on Get Veteran ID cards page.

### DIFF
--- a/pages/records/get-veteran-id-cards.md
+++ b/pages/records/get-veteran-id-cards.md
@@ -13,12 +13,6 @@ plainlanguage:
 template: detail-page
 collection: records
 children: veteranIdCards
-relatedlinks:
- - heading:
-   links:
-    - url:
-      title:
-      description:
 ---
 
 <div class="va-introtext">


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/records/get-veteran-id-cards/

## Origin of request (internal/stakeholder/user feedback)
Via migration QA we found a small bug in the original content

## Description of what's needed (edits/link changes/additions)
Remove the empty `relatedlinks:` so that this grey line doesn't show up.

<img width="1302" alt="Types_Of_Veteran_ID_Cards___Veterans_Affairs" src="https://user-images.githubusercontent.com/643678/57498225-117db000-72a9-11e9-8b3a-002fbf5b54ed.png">

 
