### PR TITLE
Fixed right margin on veterans law judge page

### DIFF
--- a/pages/decision-reviews/board-appeal/veterans-law-judge-hearing.md
+++ b/pages/decision-reviews/board-appeal/veterans-law-judge-hearing.md
@@ -34,8 +34,6 @@ You can request a video conference hearing if you want to provide testimony to a
 
 You aren't required to have a hearing. A Board hearing is always optional.
 
-</div>
-
 ## Learn more about Board hearings
 
 - [Request a Board hearing](#request-board-hearing)


### PR DESCRIPTION
## Page to edit
url: /decision-reviews/board-appeal/veterans-law-judge-hearing/

## Origin of request (internal/stakeholder/user feedback)
Internal (@bethpotts)

## Description of what's needed (edits/link changes/additions)

This PR fixes an issue where the text went passed the right margin on `/decision-reviews/board-appeal/veterans-law-judge-hearing/`

**before**:
![Screen Shot 2019-05-13 at 9 28 26 PM](https://user-images.githubusercontent.com/11021491/57664402-1c488580-75c6-11e9-89fa-ffb865069d8a.png)

**after**: 

![Screen Shot 2019-05-13 at 9 28 48 PM](https://user-images.githubusercontent.com/11021491/57664418-27031a80-75c6-11e9-9612-39bf553421f8.png)

