### PR TITLE
Remove dst from sitemap

### DIFF
--- a/pages/dst/index.md
+++ b/pages/dst/index.md
@@ -11,6 +11,7 @@ display_title: Veterans Community Care Program Eligibility Tool
 
 # This line indicates that this page is not to be built to production (www.va.gov)
 vagovprod: false
+private: true
 ---
 
 <div class="va-introtext" id="introtext">


### PR DESCRIPTION
## Page to edit
url: /dst

We're removing this from the sitemap, since it's a test page that is never going to be a real part of the site.

