### PR TITLE
Remove 2019-05-29 Outage Banner

### DIFF
--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -19,7 +19,7 @@
 #   '
 #
 
-visible: true
+visible: false
 type: warning
 title: You may have trouble signing in or using some tools or services on VA.gov
 content: >


### PR DESCRIPTION
Remove the outage banner that was put up for the 2019-05-29 outage.

