### PR TITLE
Update Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Content files for VA.gov",
   "engines": {
-    "node": "8.10.0",
+    "node": "10.15.3",
     "yarn": "1.12.3"
   },
   "scripts": {


### PR DESCRIPTION
This PR updates the version of Node to match that of https://github.com/department-of-veterans-affairs/vets-website/pull/10111. Heroku throws an error otherwise.