### PR TITLE
Remove sessionStorage.shouldRedirectExpiredSession on logout

### DIFF
--- a/pages/logout.md
+++ b/pages/logout.md
@@ -18,6 +18,7 @@ private: true
 
 <script>
   window.sessionStorage.removeItem('authReturnUrl');
+  window.sessionStorage.removeItem('shouldRedirectExpiredSession');
   window.localStorage.removeItem('hasSession');
   window.localStorage.removeItem('sessionExpiration');
   window.localStorage.removeItem('userFirstName');


### PR DESCRIPTION
## Page to edit
url: /logout

## Origin of request (internal/stakeholder/user feedback)
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18834


## Description of what's needed (edits/link changes/additions)
`sessionStorage.shouldRedirectExpiredSession` should be cleared on log out.
