### PR TITLE
Update widget markup

### DIFF
--- a/pages/burials-memorials/veterans-burial-allowance.md
+++ b/pages/burials-memorials/veterans-burial-allowance.md
@@ -8,11 +8,6 @@ order: 3
 spoke: Get benefits
 collection: burials
 children: burialsAllowance
-widgets:
-  - root: react-applicationStatus
-    timeout: 20
-    loadingMessage: Checking your application status.
-    errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
 ---
 
 <div class="va-introtext">
@@ -75,8 +70,24 @@ There's no time limit to file for a service-connected burial, plot, or interment
 
 </div>
 
-<div id="react-applicationStatus" data-widget-type="burials-app-status" class="static-page-widget">
-  <a class="usa-button-primary va-button-primary" href="/burials-and-memorials/application/530">Apply for Burial Benefits</a>
+<div data-widget-type="burials-app-status" data-widget-timeout="20">
+  <div class="loading-indicator-container">
+    <div class="loading-indicator" role="progressbar" aria-valuetext="Checking your application status."></div>
+    <span class="loading-indicator-message loading-indicator-message--normal">
+      Checking your application status.
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+      Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true">
+    <a class="usa-button-primary va-button-primary" href="/burials-and-memorials/application/530">Apply for Burial Benefits</a>
+  </span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.
+    </div>
+  </div>
 </div>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">

--- a/pages/disability/eligibility.md
+++ b/pages/disability/eligibility.md
@@ -80,7 +80,23 @@ If you've received one of these discharge statuses, you may not be eligible for 
 
 
 <div markdown="0"><br></div>
-<div id="react-applicationStatus" data-widget-type="disability-app-status"></div>
+<div data-widget-type="disability-app-status" data-widget-timeout="20">
+  <div class="loading-indicator-container">
+    <div class="loading-indicator" role="progressbar" aria-valuetext="Checking your application status."></div>
+    <span class="loading-indicator-message loading-indicator-message--normal">
+      Checking your application status.
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+      Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true"></span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.
+    </div>
+  </div>
+</div>
 
 <div itemscope itemtype="http://schema.org/Question">
 

--- a/pages/disability/how-to-file-claim.md
+++ b/pages/disability/how-to-file-claim.md
@@ -72,7 +72,23 @@ You should also know that you have up to a year from the date we receive your cl
 </div>
 
 
-<div id="react-applicationStatus" data-widget-type="disability-app-status"></div>
+<div data-widget-type="disability-app-status" data-widget-timeout="20">
+  <div class="loading-indicator-container">
+    <div class="loading-indicator" role="progressbar" aria-valuetext="Checking your application status."></div>
+    <span class="loading-indicator-message loading-indicator-message--normal">
+      Checking your application status.
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+      Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true"></span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.
+    </div>
+  </div>
+</div>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">
 

--- a/pages/education/eligibility.md
+++ b/pages/education/eligibility.md
@@ -8,11 +8,6 @@ plainlanguage: 11-02-16 certified in compliance with the Plain Writing Act
 collection: education
 spoke: Get benefits
 order: 2
-widgets:
-  - root: react-applicationStatus
-    timeout: 20
-    loadingMessage: Checking your application status.
-    errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
 gibsAlert: false
 ---
 <div itemscope itemtype="http://schema.org/FAQPage">
@@ -151,7 +146,23 @@ If you have a service-connected disability that limits your ability to work or p
 
 </div><div markdown="0"><br></div>
 
-<div id="react-applicationStatus" data-widget-type="education-app-status" class="static-page-widget"></div>
+<div data-widget-type="education-app-status" data-widget-timeout="20">
+  <div class="loading-indicator-container">
+    <div class="loading-indicator" role="progressbar" aria-valuetext="Checking your application status."></div>
+    <span class="loading-indicator-message loading-indicator-message--normal">
+      Checking your application status.
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+      Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true"></span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.
+    </div>
+  </div>
+</div>
 
 [Learn more about how to apply for education benefits](/education/how-to-apply/)
 

--- a/pages/education/how-to-apply.md
+++ b/pages/education/how-to-apply.md
@@ -23,11 +23,6 @@ relatedlinks:
     - url: /careers-employment/family-resources/
       title: Explore resources for military and Veteran family members
       description: Find out how the Veterans Employment Center can help spouses and other family members access valuable career resources.
-widgets:
-  - root: react-applicationStatus
-    timeout: 20
-    loadingMessage: Checking your application status.
-    errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
 ---
 <div itemscope itemtype ="http://schema.org/HowTo">
 <div class="va-introtext" itemprop="description">
@@ -65,7 +60,23 @@ Find out how to apply for VA education benefits as a Veteran, service member, or
 </div>
 </div>
 
-<div id="react-applicationStatus" data-widget-type="education-app-status" class="static-page-widget"></div>
+<div data-widget-type="education-app-status" data-widget-timeout="20">
+  <div class="loading-indicator-container">
+    <div class="loading-indicator" role="progressbar" aria-valuetext="Checking your application status."></div>
+    <span class="loading-indicator-message loading-indicator-message--normal">
+      Checking your application status.
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+      Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true"></span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.
+    </div>
+  </div>
+</div>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">
 

--- a/pages/education/opt-out-information-sharing.md
+++ b/pages/education/opt-out-information-sharing.md
@@ -9,12 +9,6 @@ template: detail-page
 collection: education
 children: educationInformationSharingOptOut
 order: 15
-widgets:
-  - root: react-applicationStatus
-    timeout: 20
-    loadingMessage: Checking your application status.
-    errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
-    description: Find the right VA education benefits for you, and apply to start getting help paying tuition. We can also help you find the right school or training program.
 hideFromSidebar: true
 spoke: More resources
 ---
@@ -48,7 +42,23 @@ No. Your education benefits will stay the same if you decide to opt out. You won
 
 You’ll need to fill out a short form to tell us you want to opt out of sharing this information. You can get started right now.
 
-<div id="react-applicationStatus" data-widget-type="opt-out-app-status" class="static-page-widget"></div>
+<div data-widget-type="opt-out-app-status" data-widget-timeout="20">
+  <div class="loading-indicator-container">
+    <div class="loading-indicator" role="progressbar" aria-valuetext="Checking your application status."></div>
+    <span class="loading-indicator-message loading-indicator-message--normal">
+      Checking your application status.
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+      Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true"></span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.
+    </div>
+  </div>
+</div>
 
 <b>Note</b>: If you’re signed in to your account, we can prefill part of your application based on your account details.
 

--- a/pages/pension/eligibility.md
+++ b/pages/pension/eligibility.md
@@ -19,11 +19,6 @@ relatedlinks:
     - url: /pension/aid-attendance-housebound/
       title: Aid and Attendance benefits and Housebound allowance
       description: If you need help with daily activities or you're housebound, find out how to apply for extra VA pension benefits.
-widgets:
-  - root: react-applicationStatus
-    timeout: 20
-    loadingMessage: Checking your application status.
-    errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
 ---
 
 <div class="va-introtext">
@@ -81,7 +76,22 @@ If you've received one of these discharge statuses, you may not be eligible for 
 [Learn about the VA Character of Discharge review process](/discharge-upgrade-instructions/#other-options)
 
 
-<div id="react-applicationStatus" data-widget-type="pension-app-status" class="static-page-widget">
-  <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
+<div data-widget-type="pension-app-status" data-widget-show-learn-more data-widget-timeout="20">
+  <div class="loading-indicator-container">
+    <div class="loading-indicator" role="progressbar" aria-valuetext="Checking your application status."></div>
+    <span class="loading-indicator-message loading-indicator-message--normal">
+      Checking your application status.
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+      Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true">
+    <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
+  </span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.
+    </div>
+  </div>
 </div>
-

--- a/pages/pension/how-to-apply.md
+++ b/pages/pension/how-to-apply.md
@@ -19,11 +19,6 @@ relatedlinks:
     - url: /pension/aid-attendance-housebound/
       title: Aid and Attendance benefits and Housebound allowance
       description: If you need help with daily activities or you're housebound, find out how to apply for extra VA pension benefits.
-widgets:
-  - root: react-applicationStatus
-    timeout: 20
-    loadingMessage: Checking your application status.
-    errorMessage: <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br/>Please try refreshing your browser in a few minutes.
 ---
 
 <div class="va-introtext">
@@ -51,8 +46,24 @@ Find out how to apply for tax-free VA pension benefits as a Veteran.
 - Medical information
 </div>
 
-<div id="react-applicationStatus" data-widget-type="pension-app-status" class="static-page-widget">
-  <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
+<div data-widget-type="pension-app-status" data-widget-timeout="20">
+  <div class="loading-indicator-container">
+    <div class="loading-indicator" role="progressbar" aria-valuetext="Checking your application status."></div>
+    <span class="loading-indicator-message loading-indicator-message--normal">
+      Checking your application status.
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+      Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true">
+    <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
+  </span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We’re sorry. Something went wrong when we tried to load your saved application.</strong><br>Please try refreshing your browser in a few minutes.
+    </div>
+  </div>
 </div>
 
 


### PR DESCRIPTION
This updates the static widget markup on several pages to use the same output as the Drupal template, so that we can use some update JS code that we want to use going forward.

There should be no functional difference for users and I assume that it's unlikely that we'll be adding more of these widgets in Markdown in the near future.

Related PR: https://github.com/department-of-veterans-affairs/vets-website/pull/10256