### PR TITLE
Careers page anomaly fix

### DIFF
--- a/pages/careers-employment/vocational-rehabilitation/programs/self-employment.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/self-employment.md
@@ -20,11 +20,7 @@ relatedlinks:
     - url: /careers-employment/vocational-rehabilitation/programs/independent-living/
       title: Independent Living track
       description: Learn about services that can help you live as independently as possible if you can't return to work right away.
-  - heading: More support for your small business
-    links:
-    - url: /careers-employment/veteran-owned-business-support/
-      title: Register your Veteran-Owned Small Business
-      description: Register to do business with VA and get support for your Veteran-Owned Small Business.
+
 ---
 
 <div class="va-introtext">

--- a/pages/careers-employment/vocational-rehabilitation/programs/self-employment.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/self-employment.md
@@ -99,8 +99,6 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 
 [Find out how to apply if you haven’t yet received a disability rating](/careers-employment/vocational-rehabilitation/how-to-apply/#servicemember-not-received-rating)
 
-<br>
-
 ## Get more information
 
 **We offer opportunities to get training and practical hands-on work experience at the same time through programs like:**


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/careers-employment/vocational-rehabilitation/programs/self-employment/

## Origin of request (internal/stakeholder/user feedback)
CMS migration team discovered anomaly in related link. Can't have a separate heading with a link within the rest of the related links. 

## Description of what's needed (edits/link changes/additions)

Deleted the "More support for your small business" head, text and related link.