### PR TITLE
Remove extra "| Veterans Affairs" in meta title tag

### DIFF
--- a/pages/change-address.md
+++ b/pages/change-address.md
@@ -1,7 +1,7 @@
 ---
 layout: page-breadcrumbs.html
 template: detail-page
-title: Change Your Address On File With VA | Veterans Affairs
+title: Change Your Address On File With VA
 display_title: Change your address
 heading: Change your address on file with VA
 description: Find out how to change your address on file with VA, and update other contact information in your VA.gov profile. This will update your information across several VA benefits and services, including VA health care, disability compensation, and pension benefits.


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/change-address 
heroku, to compare: https://vagov-content-pr-474.herokuapp.com/change-address

## Origin of request (internal/stakeholder/user feedback)
There's an extra `| Veterans Affairs` in the `<title>` tag, per screenshot below

## Description of what's needed (edits/link changes/additions)

Remove ` | Veterans Affairs` from the `title` frontmatter (it get inserted somewhere else).

<img width="992" alt="Change_Your_Address_On_File_With_VA___Veterans_Affairs___Veterans_Affairs" src="https://user-images.githubusercontent.com/643678/59794684-cd36f400-92d9-11e9-9672-83ba515c6a3d.png">


