### PR TITLE
Shorten <title> for POWs disability benefits

### DIFF
--- a/pages/disability/eligibility/former-pows.md
+++ b/pages/disability/eligibility/former-pows.md
@@ -1,7 +1,7 @@
 ---
 layout: page-breadcrumbs.html
-title: Disability Benefits For Former Prisoners Of War
-heading: Disability benefits for former prisoners of war (POWs)
+title: Benefits For Former Prisoners Of War (POWs)
+heading: Benefits for former prisoners of war (POWs)
 display_title: Former POWs
 description: Learn about VA disability compensation and other benefits for former prisoners of war (POWs). Learn which conditions these benefits cover and how to file your claim.
 concurrence: complete

--- a/pages/disability/eligibility/former-pows.md
+++ b/pages/disability/eligibility/former-pows.md
@@ -1,6 +1,6 @@
 ---
 layout: page-breadcrumbs.html
-title: Disability Benefits For Former Prisoners Of War (POWs)
+title: Disability Benefits For Former Prisoners Of War
 heading: Disability benefits for former prisoners of war (POWs)
 display_title: Former POWs
 description: Learn about VA disability compensation and other benefits for former prisoners of war (POWs). Learn which conditions these benefits cover and how to file your claim.


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/disability/eligibility/former-pows/
heroku: https://vagov-content-pr-475.herokuapp.com/disability/eligibility/former-pows/

## Origin of request (internal/stakeholder/user feedback)
`<title>` is limited to 70 characters in the CMS, to enforce SEO style guide. the `title` frontmatter for the above URL has 73. 

## Description of what's needed (edits/link changes/additions)
We need to remove 3 or more characters. 

