### PR TITLE
Update sentence casing for buttons

### DIFF
--- a/pages/burials-memorials/pre-need-eligibility.md
+++ b/pages/burials-memorials/pre-need-eligibility.md
@@ -104,7 +104,7 @@ We base our decision of whether or not you qualify for burial in a VA national c
 ## How do I apply?
 You can apply online right now.
 
-<a class="usa-button-primary va-button-primary" href="/burials-and-memorials/pre-need/form-10007-apply-for-eligibility">Apply for Pre-need Eligibility</a>
+<a class="usa-button-primary va-button-primary" href="/burials-and-memorials/pre-need/form-10007-apply-for-eligibility">Apply for pre-need eligibility</a>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">
 <h4 itemprop="name">You can also apply:</h4>

--- a/pages/burials-memorials/veterans-burial-allowance.md
+++ b/pages/burials-memorials/veterans-burial-allowance.md
@@ -81,7 +81,7 @@ There's no time limit to file for a service-connected burial, plot, or interment
     </span>
   </div>
   <span class="static-widget-content vads-u-display--none" aria-hidden="true">
-    <a class="usa-button-primary va-button-primary" href="/burials-and-memorials/application/530">Apply for Burial Benefits</a>
+    <a class="usa-button-primary va-button-primary" href="/burials-and-memorials/application/530">Apply for burial benefits</a>
   </span>
   <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
     <div class="usa-alert-body">

--- a/pages/careers-employment/dependent-benefits.md
+++ b/pages/careers-employment/dependent-benefits.md
@@ -98,7 +98,7 @@ If you're eligible, we'll invite you to meet with a Vocational Rehabilitation Co
 
 You can apply online right now.
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 **Note:** If the service member or Veteran in your family isn’t yet using VR&E benefits and services, they may also apply online through eBenefits.
 

--- a/pages/careers-employment/education-and-career-counseling.md
+++ b/pages/careers-employment/education-and-career-counseling.md
@@ -55,7 +55,7 @@ First, you’ll need to apply for Vocational Rehabilitation and Employment benef
   <li class="process-step list-five">If you're eligible, we’ll invite you to an orientation session at your nearest VA regional benefit office.</li>
 </ol>
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 ### You can also apply by mail
 

--- a/pages/careers-employment/vocational-rehabilitation/eligibility.md
+++ b/pages/careers-employment/vocational-rehabilitation/eligibility.md
@@ -4,7 +4,7 @@ title: Eligibility For VA Vocational Rehab And Employment
 heading: Eligibility for VA Vocational Rehab and Employment
 display_title: Eligibility
 description: Review VA Vocational Rehab and Employment (VR&amp;E) eligibility requirements for Veterans and active-duty service members. If you have a service-connected disability that limits your ability, you may be eligible for vocational rehabilitation services.
-keywords: vocational rehab, vocational rehabilitation eligibility, vocational rehab services, vocational rehab va eligibility 
+keywords: vocational rehab, vocational rehabilitation eligibility, vocational rehab services, vocational rehab va eligibility
 order: 2
 template: detail-page
 majorlinks:
@@ -80,7 +80,7 @@ If you've received one of these discharge statuses, you may not be eligible for 
 
 You can apply online right now.
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 [Learn more about how to apply for VR&E](/careers-employment/vocational-rehabilitation/how-to-apply/) <br>
 **Note:** You can apply even if you're a service member without a disability rating yet.

--- a/pages/careers-employment/vocational-rehabilitation/how-to-apply.md
+++ b/pages/careers-employment/vocational-rehabilitation/how-to-apply.md
@@ -59,7 +59,7 @@ If you’re eligible, we’ll invite you to an orientation session at your neare
 </li>
 </ol>
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 <br>
 

--- a/pages/careers-employment/vocational-rehabilitation/programs/independent-living.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/independent-living.md
@@ -106,6 +106,6 @@ If you’re eligible, a VRC will work with you to determine the severity of your
 
 ### Ready to apply?
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 [Find out how to apply if you haven't yet received a disability rating](/careers-employment/vocational-rehabilitation/how-to-apply/#servicemember-not-received-rating)

--- a/pages/careers-employment/vocational-rehabilitation/programs/long-term-services.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/long-term-services.md
@@ -99,7 +99,7 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 
 ### Ready to apply?
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 [Find out how to apply if you haven’t yet received a disability rating](/careers-employment/vocational-rehabilitation/how-to-apply/#servicemember-not-received-rating)
 

--- a/pages/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/rapid-access-to-employment.md
@@ -95,7 +95,7 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 
 ### Ready to apply?
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 [Find out how to apply if you haven’t yet received a disability rating](/careers-employment/vocational-rehabilitation/how-to-apply/#servicemember-not-received-rating)
 

--- a/pages/careers-employment/vocational-rehabilitation/programs/reemployment.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/reemployment.md
@@ -93,7 +93,7 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 
 ### Ready to apply?
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 [Find out how to apply if you haven’t yet received a disability rating](/careers-employment/vocational-rehabilitation/how-to-apply/#servicemember-not-received-rating)
 

--- a/pages/careers-employment/vocational-rehabilitation/programs/self-employment.md
+++ b/pages/careers-employment/vocational-rehabilitation/programs/self-employment.md
@@ -95,7 +95,7 @@ If you're eligible, we'll invite you to an orientation session at your nearest V
 
 ### Ready to apply?
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=vocational-rehabilitation-and-employment">Go to eBenefits to apply</a>
 
 [Find out how to apply if you haven’t yet received a disability rating](/careers-employment/vocational-rehabilitation/how-to-apply/#servicemember-not-received-rating)
 

--- a/pages/change-direct-deposit-beta.md
+++ b/pages/change-direct-deposit-beta.md
@@ -44,7 +44,7 @@ Please call us at <a href="tel:+18008271000">800-827-1000</a>. We're here Monday
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">You’ll need to sign in to eBenefits to change your VA direct deposit and contact information online.</h4>
   <p class="usa-alert-text">To use this feature, you'll need a Premium <b>DS Logon</b> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <b>DS Logon</b> account to Premium.<br>
-      <a class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information">Go to eBenefits to Change Your Information</a>
+      <a class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information">Go to eBenefits to change your information</a>
     </p>
   </div>
 </div>

--- a/pages/change-direct-deposit.md
+++ b/pages/change-direct-deposit.md
@@ -4,10 +4,10 @@ template: level2-index
 title: Change Your VA Direct Deposit Information
 heading: Change your VA direct deposit information
 display_title: Change your VA direct deposit information
-description: Change VA direct deposit information for your VA disability compensation, pension, or education benefits online. Sign in or register for a Premium account to update your information. 
+description: Change VA direct deposit information for your VA disability compensation, pension, or education benefits online. Sign in or register for a Premium account to update your information.
 keywords: va direct deposit, change va direct deposit
 lastupdate:
-      
+
 ---
 
 <div itemscope itemtype="http://schema.org/FAQPage">
@@ -22,7 +22,7 @@ Change VA direct deposit and contact information for certain benefits online.
     <h4 class="usa-alert-heading">You’ll need to sign in to eBenefits to change your VA direct deposit and contact information online.</h4>
   <p class="usa-alert-text"><br>
     To use this feature, you'll need a Premium <b>DS Logon</b> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <b>DS Logon</b> account to Premium.<br>
-      <a class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information">Go to eBenefits to Change Your Information</a>
+      <a class="usa-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information">Go to eBenefits to change your information</a>
     </p>
   </div>
 </div>

--- a/pages/decision-reviews/after-you-request-review.md
+++ b/pages/decision-reviews/after-you-request-review.md
@@ -17,16 +17,16 @@ You don’t need to do anything unless VA sends you a letter asking for more inf
 
 If you requested a decision review and haven’t heard back from VA yet, please don’t request another review. Call VA at <a href="tel:+18008271000">800-827-1000</a>.
 
-<a href="https://www.va.gov/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Claim or Appeal</a>
+<a href="https://www.va.gov/claim-or-appeal-status/" class="usa-button-primary">Track the status of your claim or appeal</a>
 
 ## What if I need help?
-A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review. 
+A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review.
 <br>
 [Get help requesting a decision review](/decision-reviews/get-help-with-review-request/)
 
 ## What if I want to choose a different review option after I’ve submitted a form?
 
-If you’ve submitted a form and want to change your review option, you can send in a new decision review request form within 1 year from the date on your VA decision. You must include a letter that says you want to withdraw your existing review and switch to a different option. 
+If you’ve submitted a form and want to change your review option, you can send in a new decision review request form within 1 year from the date on your VA decision. You must include a letter that says you want to withdraw your existing review and switch to a different option.
 
 If you requested a Board Appeal and want to switch to a different appeal option, you can send in a new Board Appeal form with a different option selected. You can switch appeal options within 1 year from the date on your VA decision or 60 days from the date you submitted your original form.
 

--- a/pages/decision-reviews/board-appeal.md
+++ b/pages/decision-reviews/board-appeal.md
@@ -184,7 +184,7 @@ If you disagree with the Board’s decision and have new and relevant evidence t
 
 You don’t need to do anything while you wait unless VA sends you a letter asking for more information. If VA schedules exams for you, be sure not to miss them.
 
-<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Appeal </a>
+<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the status of your appeal </a>
 
 ## What if I need help?
 

--- a/pages/decision-reviews/board-appeal/after-board-appeal-decision.md
+++ b/pages/decision-reviews/board-appeal/after-board-appeal-decision.md
@@ -15,7 +15,7 @@ If you disagree with the Board’s decision, you have 2 options. You can file a 
 ### Add new and relevant evidence
 
 If you have new and relevant evidence, you can file a Supplemental Claim (VA Form 20-0995) to continue your review.
-<br> 
+<br>
 [Learn more about Supplemental Claims](/decision-reviews/supplemental-claim/) <br>
 [Download VA Form 20-0995 (PDF)](/decision-reviews/forms/supplemental-claim-20-0995.pdf)
 
@@ -23,15 +23,15 @@ If you have new and relevant evidence, you can file a Supplemental Claim (VA For
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="far fa-copy"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
       You must add new evidence that VA didn’t have before that supports your case.
   </div>
-</div>  
+</div>
 
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">
-      Mark your calendar 
+      Mark your calendar
     </h4>
     <p class="usa-alert-text">
       You have <b>1 year</b> from the date on your decision to file a Supplemental Claim.
@@ -56,10 +56,10 @@ You can request a review of the Board’s decision from the U.S. Court of Appeal
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">
-      Mark your calendar 
+      Mark your calendar
     </h4>
     <p class="usa-alert-text">
-      You have <b>120 days</b> from the date on your decision to file a Court Appeal. 
+      You have <b>120 days</b> from the date on your decision to file a Court Appeal.
       <br>
       <b>Note:</b> A Court Appeal must be filed with the Court, not with VA.
     </p>
@@ -71,11 +71,11 @@ You can request a review of the Board’s decision from the U.S. Court of Appeal
 
 You don’t need to do anything while you wait unless VA sends you a letter asking for more information. If VA schedules exams for you, be sure not to miss them.
 
-<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Claim </a>
+<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the status of your claim </a>
 
 ## What if I need help?
 A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review.
-<br> 
+<br>
 [Get help requesting a decision review](/decision-reviews/get-help-with-review-request/)
 
 ## What if I have more questions?

--- a/pages/decision-reviews/fiduciary-claims.md
+++ b/pages/decision-reviews/fiduciary-claims.md
@@ -19,7 +19,7 @@ If you disagree with a VA decision on a fiduciary claim, you can choose one of t
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">
-      Mark your calendar 
+      Mark your calendar
     </h4>
     <p class="usa-alert-text">
       You have <b>1 year</b> from the date on your decision to request a decision review.
@@ -30,9 +30,9 @@ If you disagree with a VA decision on a fiduciary claim, you can choose one of t
 
 ## Decision review options
 
-### Add new and relevant evidence	
+### Add new and relevant evidence
 
-The Supplemental Claim option isn’t available for fiduciary claims. You can file a new claim if you have new evidence. 	
+The Supplemental Claim option isn’t available for fiduciary claims. You can file a new claim if you have new evidence.
 <br>
 
 Please choose one of the options below for your next review.
@@ -41,7 +41,7 @@ Please choose one of the options below for your next review.
 
 [Download VA Form 20-0996: Higher-Level Review (PDF)](/decision-reviews/forms/higher-level-review-20-0996.pdf)
 
-When you choose a Higher-Level Review, you’re asking for another review of the same evidence. A senior reviewer will take another look at your case and determine whether the decision can be changed based on a difference of opinion or an error. 
+When you choose a Higher-Level Review, you’re asking for another review of the same evidence. A senior reviewer will take another look at your case and determine whether the decision can be changed based on a difference of opinion or an error.
 <br>
 [Learn how to request a Higher-Level Review](/decision-reviews/higher-level-review/)
 <br>
@@ -49,10 +49,10 @@ When you choose a Higher-Level Review, you’re asking for another review of the
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-ban"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
      You can’t submit any evidence.
   </div>
-</div>      
+</div>
 <div class ="vads-u-display--flex vads-u-margin-y--1">
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-phone"></i></span>
@@ -60,7 +60,7 @@ When you choose a Higher-Level Review, you’re asking for another review of the
   <div class="vads-u-flex--1">
   You and/or your representative can speak with the reviewer on the phone. You can tell them why you think the decision should be changed and identify errors.
   </div>
-</div>  
+</div>
 
 <div class="card information">
   <span class="number"><span class="heading-level-3"><i class="far fa-clock vads-u-margin-right--1p5"></i>4-5 months</span></span>
@@ -78,7 +78,7 @@ You can request a Higher-Level Review of an initial claim. This option isn’t a
 [Download VA Form 10182: Board Appeal (PDF)](/decision-reviews/forms/board-appeal-10182.pdf)
 <br>
 
-A judge at the Board of Veterans’ Appeals in Washington, D.C., will review your case. 
+A judge at the Board of Veterans’ Appeals in Washington, D.C., will review your case.
 <br>
 [Learn more about how to request a Board Appeal](/decision-reviews/board-appeal/)
 
@@ -91,18 +91,18 @@ A judge at the Board of Veterans’ Appeals in Washington, D.C., will review you
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="far fa-copy"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
      You have the option to add new evidence that a judge will review.
-  </div>   
+  </div>
 </div>
-<div class ="vads-u-display--flex vads-u-margin-y--1">    
+<div class ="vads-u-display--flex vads-u-margin-y--1">
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-user"></i></span>
   </div>
-  <div class="vads-u-flex--1"> 
+  <div class="vads-u-flex--1">
     You also have the option to request a hearing with a judge. A video conference hearing will take place at a VA location near you.
   </div>
-</div>  
+</div>
 
 <div class="card information">
   <span class="number"><span class="heading-level-3"><i class="far fa-clock vads-u-margin-right--1p5"></i>Longer</span></span>
@@ -115,7 +115,7 @@ You can request a Board Appeal after an initial claim or Higher-Level Review dec
 
 ## After a Board decision
 
-If you disagree with the Board’s decision and have new and relevant evidence that supports your case, you can file a Supplemental Claim. You can also appeal to the U.S. Court of Appeals for Veterans Claims. 
+If you disagree with the Board’s decision and have new and relevant evidence that supports your case, you can file a Supplemental Claim. You can also appeal to the U.S. Court of Appeals for Veterans Claims.
 <br>
 [Learn more about your options after a Board decision](/decision-reviews/board-appeal/after-board-appeal-decision/)
 
@@ -125,11 +125,11 @@ If you disagree with the Board’s decision and have new and relevant evidence t
 
 You don’t need to do anything while you wait unless VA sends you a letter asking for more information. If VA schedules exams for you, be sure not to miss them.
 
-<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Appeal</a>
+<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the status of your appeal</a>
 
 ## What if I need help?
 
-A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review. 
+A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review.
 <br>
 [Get help requesting a decision review](/decision-reviews/get-help-with-review-request/)
 

--- a/pages/decision-reviews/higher-level-review.md
+++ b/pages/decision-reviews/higher-level-review.md
@@ -7,28 +7,28 @@ hidesidenav: true
 ---
 <br>
 <div itemprop="description" class="va-introtext">
-If you disagree with VA’s decision, you can request to have a senior reviewer take a new look at your case. The reviewer will determine whether the decision can be changed based on a difference of opinion or an error. 
+If you disagree with VA’s decision, you can request to have a senior reviewer take a new look at your case. The reviewer will determine whether the decision can be changed based on a difference of opinion or an error.
 </div>
 <br>
 <div class ="vads-u-display--flex vads-u-margin-y--1">
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-ban"></i></span>
   </div>
-  <div class="vads-u-flex--1">    
+  <div class="vads-u-flex--1">
       You can’t submit any evidence.
   </div>
-</div>      
+</div>
 <div class ="vads-u-display--flex vads-u-margin-y--1">
   <div class="vads-u-flex--auto">
-    <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-phone"></i></span>  
+    <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-phone"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
     You and/or your representative can speak with the reviewer on the phone. You can tell them why you think the decision should be changed and identify errors.
   </div>
-</div>    
+</div>
 
 <div class="feature" markdown="0">
-  
+
 ### Can I request a Higher-Level Review?
 
 You can request a Higher-Level Review of an initial claim or Supplemental Claim decision. This option isn’t available after a Higher-Level Review or Board Appeal. It’s also not available if you’re one of multiple people claiming the same benefit (this is rare).
@@ -42,7 +42,7 @@ You can request a Higher-Level Review of an initial claim or Supplemental Claim 
 
 ## What should I expect if I request a call with a senior reviewer?
 
-If you request an informal conference with a senior reviewer, they’ll call the phone number that you or your representative provided on the Higher-Level Review form to schedule a time to discuss your case with you. The senior reviewer will try to reach you or your representative by phone twice. If no one answers, they’ll leave a voice mail. 
+If you request an informal conference with a senior reviewer, they’ll call the phone number that you or your representative provided on the Higher-Level Review form to schedule a time to discuss your case with you. The senior reviewer will try to reach you or your representative by phone twice. If no one answers, they’ll leave a voice mail.
 
 During the call, you and/or your representative can talk about why you think the decision should be changed and identify errors. There won’t be transcripts of this call.
 
@@ -66,12 +66,12 @@ The most common benefit type is compensation, but if you’re unsure, check your
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-phone"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
       You and/or your representative can speak with the reviewer on the phone. You can tell them why you think the decision should be changed and identify errors.
   </div>
 </div>
-<br>      
-To schedule an informal conference, select times and list a phone number in Part II of the form. A reviewer will call 2-4 weeks after VA processes your request. 
+<br>
+To schedule an informal conference, select times and list a phone number in Part II of the form. A reviewer will call 2-4 weeks after VA processes your request.
 
 </li>
 
@@ -86,16 +86,16 @@ You can include all or just some of the issues VA has decided. You’ll need to 
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-ban"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
      You can’t submit any evidence.
   </div>
-</div>      
+</div>
 <br>
 
 **What if I have new and relevant evidence?**
 <br>
 If you have evidence to submit, please select another review option.
-<br> 
+<br>
 [Learn more about the review options](/decision-reviews/)
 </li>
 
@@ -121,14 +121,14 @@ Janesville, WI 53547-4444<br>
 
 <ul class="usa-accordion process-accordion">
   <li>
-  <button class="usa-button-unstyled usa-accordion-button" 
+  <button class="usa-button-unstyled usa-accordion-button"
     aria-controls="VA-other-benefit-addresses">Find addresses for other benefit types</button>
     <div id="VA-other-benefit-addresses" class="usa-accordion-content" >
 
 <div class="vads-l-row medium-screen:vads-u-margin-x--neg2">
   <div class="vads-l-col--12 medium-screen:vads-l-col--6 medium-screen:vads-u-padding-x--2">
     <h4>Pension/Survivors benefits</h4>
-      <p>If you live in AK, AZ, CA, CO, HI, ID, IA, KS, MN, MT, NB, NV, NM, ND, OK, OR, SD, TX, 
+      <p>If you live in AK, AZ, CA, CO, HI, ID, IA, KS, MN, MT, NB, NV, NM, ND, OK, OR, SD, TX,
       UT, WA, WY, Mexico, Central America, South America, or the Caribbean</p>
       <p class="va-address-block">
         Department of Veterans Affairs<br>
@@ -234,7 +234,7 @@ form.<br>
 
 **In person**
 <br>
-Bring your completed form to a regional benefit office. 
+Bring your completed form to a regional benefit office.
 <br>
 [Find a regional benefit office near you](/find-locations/)
 <br>
@@ -250,7 +250,7 @@ You can also ask a regional benefit office for a copy of this form to fill out. 
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">
-      Mark your calendar 
+      Mark your calendar
     </h4>
     <p class="usa-alert-text">
       You have <b>1 year</b> from the date on your decision to file a Higher-Level Review.
@@ -263,7 +263,7 @@ You can also ask a regional benefit office for a copy of this form to fill out. 
 
 You don’t need to do anything while you wait, unless VA sends you a letter asking for more information. If VA schedules exams for you, be sure not to miss them.
 
-<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Claim </a>
+<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the status of your claim </a>
 
 ## What if I need help?
 A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review. <br>

--- a/pages/decision-reviews/index.md
+++ b/pages/decision-reviews/index.md
@@ -185,7 +185,7 @@ If you disagree with the Board’s decision and have new and relevant evidence t
 You don’t need to do anything while you wait unless VA sends you a letter asking for
 more information. If VA schedules exams for you, be sure not to miss them.
 
-<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Claim or Appeal</a>
+<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the status of your claim or appeal</a>
 
 ## What if I need help?
 

--- a/pages/decision-reviews/insurance-claims.md
+++ b/pages/decision-reviews/insurance-claims.md
@@ -13,7 +13,7 @@ If you disagree with a VA decision on an insurance claim, you can choose one of 
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">
-      Mark your calendar 
+      Mark your calendar
     </h4>
     <p class="usa-alert-text">
       You have <b>1 year</b> from the date on your decision to request a decision review.
@@ -27,7 +27,7 @@ If you disagree with a VA decision on an insurance claim, you can choose one of 
 
 [Download VA Form 20-0995: Supplemental Claim (PDF)](/decision-reviews/forms/supplemental-claim-20-0995.pdf)
 
-When you choose to file a Supplemental Claim, you’re adding new evidence that supports your case or identifying evidence for review. A reviewer will determine whether the new evidence changes the decision. 
+When you choose to file a Supplemental Claim, you’re adding new evidence that supports your case or identifying evidence for review. A reviewer will determine whether the new evidence changes the decision.
 <br>
 [Learn how to file a Supplemental Claim](/decision-reviews/supplemental-claim/)
 <br>
@@ -36,10 +36,10 @@ When you choose to file a Supplemental Claim, you’re adding new evidence that 
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="far fa-copy"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
     You must add evidence that VA didn’t have before that supports your case.
   </div>
-</div>  
+</div>
 <br>
 <div class="card information">
   <span class="number"><span class="heading-level-3"><i class="far fa-clock vads-u-margin-right--1p5"></i>4-5 months</span></span>
@@ -53,7 +53,7 @@ When you choose to file a Supplemental Claim, you’re adding new evidence that 
 [Download VA Form 20-0996: Higher-Level Review (PDF)](/decision-reviews/forms/higher-level-review-20-0996.pdf)
 <br>
 
-When you choose to request a Higher-Level Review, you’re asking for another review of the same evidence. A senior reviewer will take another look at your case and determine whether the decision can be changed based on a difference of opinion or an error. 
+When you choose to request a Higher-Level Review, you’re asking for another review of the same evidence. A senior reviewer will take another look at your case and determine whether the decision can be changed based on a difference of opinion or an error.
 <br>
 [Learn how to request a Higher-Level Review](/decision-reviews/higher-level-review/)
 <br>
@@ -62,10 +62,10 @@ When you choose to request a Higher-Level Review, you’re asking for another re
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-ban"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
      You can’t submit any evidence.
   </div>
-</div>      
+</div>
 <div class ="vads-u-display--flex vads-u-margin-y--1">
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-phone"></i></span>
@@ -73,7 +73,7 @@ When you choose to request a Higher-Level Review, you’re asking for another re
   <div class="vads-u-flex--1">
   You and/or your representative can speak with the reviewer on the phone. You can tell them why you think the decision should be changed and identify errors.
   </div>
-</div>   
+</div>
 <br>
 <div class="card information">
   <span class="number"><span class="heading-level-3"><i class="far fa-clock vads-u-margin-right--1p5"></i>4-5 months</span></span>
@@ -89,7 +89,7 @@ You can request a Higher-Level Review of an initial claim or Supplemental Claim 
 ### Appeal to a Veterans Law Judge
 [Download VA Form 10182: Board Appeal (PDF)](/decision-reviews/forms/board-appeal-10182.pdf)
 
-A judge at the Board of Veterans’ Appeals in Washington, D.C., will review your case. 
+A judge at the Board of Veterans’ Appeals in Washington, D.C., will review your case.
 <br>
 [Learn more about how to request a Board Appeal](/decision-reviews/board-appeal/)
 
@@ -101,18 +101,18 @@ A judge at the Board of Veterans’ Appeals in Washington, D.C., will review you
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="far fa-copy"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
      You have the option to add new evidence that will be reviewed by a judge.
-  </div>   
+  </div>
 </div>
-<div class ="vads-u-display--flex vads-u-margin-y--1">    
+<div class ="vads-u-display--flex vads-u-margin-y--1">
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-user"></i></span>
   </div>
-  <div class="vads-u-flex--1"> 
+  <div class="vads-u-flex--1">
     You have the option to request a hearing with a judge. A video conference hearing will take place at a VA location near you.
   </div>
-</div>  
+</div>
 
 <br>
 
@@ -133,7 +133,7 @@ You also have the option to bring an action in a United States district court. Y
 ## After a Board decision
 
 If you disagree with the Board’s decision and have new and relevant evidence that supports your case, you can file a Supplemental Claim. You can also appeal to the U.S. Court of Appeals for Veterans Claims.
-<br> 
+<br>
 [Learn more about your options after a Board decision](/decision-reviews/board-appeal/after-board-appeal-decision/)
 
 ## What happens next?
@@ -142,11 +142,11 @@ If you disagree with the Board’s decision and have new and relevant evidence t
 
 You don’t need to do anything while you wait unless VA sends you a letter asking for more information. If VA schedules exams for you, be sure not to miss them.
 
-<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Appeal</a>
+<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the status of your appeal</a>
 
 ## What if I need help?
 
-A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review. 
+A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review.
 <br>
 [Get help requesting a decision review](/decision-reviews/get-help-with-review-request/)
 

--- a/pages/decision-reviews/multiple-party-claims.md
+++ b/pages/decision-reviews/multiple-party-claims.md
@@ -13,10 +13,10 @@ If you’re one of multiple people claiming the right to the same benefit, you h
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">
-      Mark your calendar 
+      Mark your calendar
     </h4>
     <p class="usa-alert-text">
-      You have <b>60 days</b> from the date on your decision to request a Board Appeal. 
+      You have <b>60 days</b> from the date on your decision to request a Board Appeal.
     </p>
   </div>
 </div>
@@ -24,13 +24,13 @@ If you’re one of multiple people claiming the right to the same benefit, you h
 
 ## Can I add new evidence?
 
-You have the option to add new evidence for a judge to review. You'll have to submit this evidence within 90 days from the date VA receives your Board Appeal form. 
+You have the option to add new evidence for a judge to review. You'll have to submit this evidence within 90 days from the date VA receives your Board Appeal form.
 
 This option will take longer.
 
 ## Can I request a hearing?
 
-You have the option to request a hearing with a judge. A video conference hearing will take place at a VA location near you. 
+You have the option to request a hearing with a judge. A video conference hearing will take place at a VA location near you.
 
 This option will take longer.
 
@@ -45,26 +45,26 @@ The hearing will be transcribed and added to your appeal file. You can add new a
 
 To request a Board Appeal, fill out the Decision Review Request: Board Appeal (VA Form 10182).
 <br>
-[Download VA Form 10182 (PDF)](/decision-reviews/forms/board-appeal-10182.pdf) 
+[Download VA Form 10182 (PDF)](/decision-reviews/forms/board-appeal-10182.pdf)
 
 <ol class="process">
   <li class="process-step list-one">
-    
+
 ### Choose one of the 3 options to appeal with a Veterans Law Judge
 
 **Direct Review**
 <br>
-If you want a Veterans Law Judge to review your case as quickly as possible, choose a Direct Review. 
+If you want a Veterans Law Judge to review your case as quickly as possible, choose a Direct Review.
 <br>
 
 <div class ="vads-u-display--flex vads-u-margin-y--1">
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="fas fa-ban"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
       You can’t submit any evidence.
   </div>
-</div>  
+</div>
 
 <div class="card information">
   <span class="number"><span class="heading-level-3"><i class="far fa-clock vads-u-margin-right--1p5"></i>About 1 year</span></span>
@@ -79,10 +79,10 @@ If you have additional evidence for a Veterans Law Judge to review, choose Evide
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="far fa-copy"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
       You must submit evidence within 90 days of the date VA receives your Board Appeal form.
   </div>
-</div>  
+</div>
 
 <div class="card information">
   <span class="number"><span class="heading-level-3"><i class="far fa-clock vads-u-margin-right--1p5"></i>Longer</span></span>
@@ -92,7 +92,7 @@ If you have additional evidence for a Veterans Law Judge to review, choose Evide
 
 **Hearing Request**
 <br>
-If you want a video conference hearing with a Veterans Law Judge at a nearby VA location, choose a Hearing Request. 
+If you want a video conference hearing with a Veterans Law Judge at a nearby VA location, choose a Hearing Request.
 
 At your hearing, you and a Veterans Law Judge will have a conversation, and they’ll ask you questions about your appeal. Your hearing will be transcribed and added to your appeal file. <br>
 [Learn more about hearings and how to request one](/decision-reviews/board-appeal/veterans-law-judge-hearing/)
@@ -101,10 +101,10 @@ At your hearing, you and a Veterans Law Judge will have a conversation, and they
   <div class="vads-u-flex--auto">
     <span class="heading-level-3 vads-u-margin-right--1p5"><i class="far fa-copy"></i></span>
   </div>
-  <div class="vads-u-flex--1">  
+  <div class="vads-u-flex--1">
       You can add new and relevant evidence within 90 days after the hearing, but it isn’t required.
   </div>
-</div>  
+</div>
 
 <div class="card information">
   <span class="number"><span class="heading-level-3"><i class="far fa-clock vads-u-margin-right--1p5"></i>Longer</span></span>
@@ -139,8 +139,8 @@ Washington, D.C. 20038<br>
 
 **In person**
 
-Bring your completed form to a regional benefit office. 
-<br> 
+Bring your completed form to a regional benefit office.
+<br>
 [Find a regional benefit office near you](/find-locations/)
 
 **By fax**
@@ -160,10 +160,10 @@ If you disagree with the Board’s decision, you can appeal to the U.S. Court of
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">
-      Mark your calendar 
+      Mark your calendar
     </h4>
     <p class="usa-alert-text">
-      You have <b>120 days</b> from the date on your decision to file a Court Appeal. 
+      You have <b>120 days</b> from the date on your decision to file a Court Appeal.
       <br>
       <b>Note:</b> A Court Appeal must be filed with the Court, not with VA.
     </p>
@@ -176,12 +176,12 @@ If you disagree with the Board’s decision, you can appeal to the U.S. Court of
 
 You don’t need to do anything while you wait unless VA sends you a letter asking for more information. If VA schedules exams for you, be sure not to miss them.
 
-<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Appeal</a>
+<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the status of your appeal</a>
 
 ## What if I need help?
 
 A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review.
-<br> 
+<br>
 [Get help requesting a decision review](/decision-reviews/get-help-with-review-request/)
 
 ## What if I have more questions?

--- a/pages/decision-reviews/supplemental-claim.md
+++ b/pages/decision-reviews/supplemental-claim.md
@@ -9,13 +9,13 @@ hidesidenav: true
 <br>
 
 <div itemprop="description" class="va-introtext">
-When you choose to file a Supplemental Claim, you’re adding new evidence that’s relevant to your case or identifying new evidence for review. A reviewer will determine whether the new evidence changes the decision. 
+When you choose to file a Supplemental Claim, you’re adding new evidence that’s relevant to your case or identifying new evidence for review. A reviewer will determine whether the new evidence changes the decision.
 </div>
 
 <span class="heading-level-3" style="margin-right: 1.5rem"><i class="far fa-copy"></i></span> You must add evidence VA didn’t have before that’s relevant to your case.
 
 <div class="feature" markdown="0">
-  
+
 ### Can I file a Supplemental Claim?
 
 You can file a Supplemental Claim within <b>1 year</b> of a decision if you have new evidence, unless one of these rare situations applies to you. You have a: <br>
@@ -39,7 +39,7 @@ You can submit evidence yourself, or you can ask VA to get evidence, like medica
 
 ## How do I file a Supplemental Claim with new evidence?
 To file a Supplemental Claim, fill out the Decision Review Request: Supplemental Claim (VA Form 20-0995). <br>
-<a href="/decision-reviews/forms/supplemental-claim-20-0995.pdf">Download VA Form 20-0995 (PDF)</a> 
+<a href="/decision-reviews/forms/supplemental-claim-20-0995.pdf">Download VA Form 20-0995 (PDF)</a>
 
 <ol class="process">
 <li class="process-step list-one">
@@ -61,7 +61,7 @@ You can include all or just some of the issues VA decided. You must list the iss
 
 ### Gather new and relevant evidence to submit
 
-<span class="heading-level-3 vads-u-margin-right--1p5"><i class="far fa-copy"></i></span> You must add new and relevant evidence (supporting documents) or identify evidence you’d like VA to gather for review. 
+<span class="heading-level-3 vads-u-margin-right--1p5"><i class="far fa-copy"></i></span> You must add new and relevant evidence (supporting documents) or identify evidence you’d like VA to gather for review.
 
 **List the location(s) of VA evidence in Part III**. <br>
 VA can help you get evidence if it’s at a VA medical center or other federal facility. For more details, see the instructions for completing the form.
@@ -95,14 +95,14 @@ Janesville, WI 53547-4444<br>
 
 <ul class="usa-accordion process-accordion">
   <li>
-  <button class="usa-button-unstyled usa-accordion-button" 
+  <button class="usa-button-unstyled usa-accordion-button"
     aria-controls="VA-other-benefit-addresses">Find addresses for other benefit types</button>
     <div id="VA-other-benefit-addresses" class="usa-accordion-content" >
 
 <div class="vads-l-row medium-screen:vads-u-margin-x--neg2">
   <div class="vads-l-col--12 medium-screen:vads-l-col--6 medium-screen:vads-u-padding-x--2">
     <h4>Pension/Survivors benefits</h4>
-      <p>If you live in AK, AZ, CA, CO, HI, ID, IA, KS, MN, MT, NB, NV, NM, ND, OK, OR, SD, TX, 
+      <p>If you live in AK, AZ, CA, CO, HI, ID, IA, KS, MN, MT, NB, NV, NM, ND, OK, OR, SD, TX,
       UT, WA, WY, Mexico, Central America, South America, or the Caribbean</p>
       <p class="va-address-block">
         Department of Veterans Affairs<br>
@@ -139,7 +139,7 @@ Janesville, WI 53547-4444<br>
         Fax: 844-655-1604<br>
       </p>
   </div>
-  
+
   <div class="vads-l-col--12 medium-screen:vads-l-col--6 medium-screen:vads-u-padding-x--2">
     <h4>National Cemetery Administration</h4>
       <p class="va-address-block">
@@ -221,7 +221,7 @@ You can also ask a regional benefit office for a copy of this form to fill out. 
 <div class="usa-alert usa-alert-info">
   <div class="usa-alert-body">
     <h4 class="usa-alert-heading">
-      Mark your calendar 
+      Mark your calendar
     </h4>
     <p class="usa-alert-text">
       You have <b>1 year</b> from the date on your decision to file a Supplemental Claim.
@@ -234,11 +234,11 @@ You can also ask a regional benefit office for a copy of this form to fill out. 
 
 You don’t need to do anything while you’re waiting unless VA sends you a letter asking for more information. If VA schedules exams for you, be sure not to miss them.
 
-<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the Status of Your Claim</a>
+<a href="/claim-or-appeal-status/" class="usa-button-primary">Track the status of your claim</a>
 
 
 ## What if I need help?
-A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review. 
+A Veterans Service Organization or VA-accredited attorney or agent can help you request a decision review.
 <br>
 [Get help requesting a decision review](/decision-reviews/get-help-with-review-request/)
 

--- a/pages/disability/add-remove-dependent.md
+++ b/pages/disability/add-remove-dependent.md
@@ -18,10 +18,10 @@ relatedlinks:
     - url: /life-insurance/
 
       title: Life insurance
-      description: Explore your VA life insurance options, manage your policy, and file claims.  
+      description: Explore your VA life insurance options, manage your policy, and file claims.
     - url: /education/survivor-dependent-benefits/
       title: Transfer your Post-9/11 GI Bill benefits to your spouse and dependents
-      description: If you have unused Post-9/11 GI Bill benefits, find out if you can transfer your benefits to your spouse or dependent children.     
+      description: If you have unused Post-9/11 GI Bill benefits, find out if you can transfer your benefits to your spouse or dependent children.
 
 ---
 <div itemscope itemtype="http://schema.org/FAQPage">
@@ -99,13 +99,13 @@ You can file a claim for additional compensation for a child or spouse online ri
 
 **Note:** You may need to provide more information or forms along with your claim.
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=dependent-compensation">Go to eBenefits to Add a Dependent Child or Spouse</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=dependent-compensation">Go to eBenefits to add a dependent child or spouse</a>
 
 **If you’re claiming your child who became permanently disabled before they turned 18,** you’ll need to turn in all private medical records relating to the child’s disabilities with your application.
 
 **If your dependent is a child who’s between 18 and 23 years old and attending school full time,** you’ll also need to submit a Request for Approval of School Attendance (VA Form 21-674) with your application. <br>
 
-[Download VA Form 21-674 (PDF)](https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf) 
+[Download VA Form 21-674 (PDF)](https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf)
 
 ### To file a claim for additional disability compensation for a dependent parent
 
@@ -125,11 +125,11 @@ Janesville, WI 53547-4444 <br>
 
  <a href="tel:+18445317817">844-531-7817</a> if you live in the U.S., **or** <br>
  <a href="tel:+12485244260">+1-248-524-4260</a> if you live outside of the U.S.
- 
+
 ## What if I need help with my claim?
- 
+
 You can work with an accredited Veterans Service Officer (VSO). We trust these professionals because they’re trained and certified in the VA claims and appeals process. A VSO can answer your questions or even file your claim for you.<br>
-[Get help filing your claim](/disability/get-help-filing-claim/) 
+[Get help filing your claim](/disability/get-help-filing-claim/)
 
 ## More questions about adding a dependent to your VA disability compensation
 

--- a/pages/disability/after-you-file-claim.md
+++ b/pages/disability/after-you-file-claim.md
@@ -49,7 +49,7 @@ Find out what happens to your claim after you file for disability compensation.
 
 You don’t need to do anything unless we send you a letter asking for more information. If we schedule any exams for you, be sure not to miss them. You can check the status of your claim online. The time frame you see there may vary based on how complex your claim is.
 
-<a class="usa-button-primary" href="/claim-or-appeal-status">Track the Status of Your Claim</a>
+<a class="usa-button-primary" href="/claim-or-appeal-status">Track the status of your claim</a>
 
 <div markdown="0"><br></div>
 

--- a/pages/disability/file-an-appeal.md
+++ b/pages/disability/file-an-appeal.md
@@ -24,7 +24,7 @@ You have the right to appeal any benefits decision made by the Veterans Benefits
 
 When the regional office for the Veterans Benefits Administration receives your Notice of Disagreement, you’ll be able to check the status of your appeal online.
 
-<a class="usa-button-primary" href="/track-claims">Track Your Appeal</a>
+<a class="usa-button-primary" href="/track-claims">Track your appeal</a>
 
  </div>
 </div>
@@ -56,8 +56,8 @@ After the Veterans Benefits Administration makes a decision on your claim, you c
       <div>
         <h4>File a Notice of Disagreement (NOD)</h4>
         <p>
-        By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within one year of the date on the letter notifying you of the claim decision. <br> 
-        <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement, VA Form 21-0958 (PDF)</a> 
+        By filing a Notice of Disagreement, you begin the appeals process. You’ll need to file a Notice of Disagreement within one year of the date on the letter notifying you of the claim decision. <br>
+        <a href="https://www.vba.va.gov/pubs/forms/VBA-21-0958-ARE.pdf">Download a Notice of Disagreement, VA Form 21-0958 (PDF)</a>
         </p>
         <p>
         Fill out your Notice of Disagreement and mail it to the address provided on the VA claim decision notice letter you received, or bring it to your local regional office. An accredited representative can help you file a Notice of Disagreement. <a href="/disability/get-help-filing-claim/">Get help filing your appeal</a>

--- a/pages/disability/how-to-file-claim.md
+++ b/pages/disability/how-to-file-claim.md
@@ -134,7 +134,7 @@ If you have a power of attorney and need to update their information, please cal
 
 You don’t need to do anything while you’re waiting unless we send you a letter asking for more information. If we schedule exams for you, be sure not to miss them.
 
-<a class="usa-button-primary" href="/track-claims">Track the Status of Your Claim</a>
+<a class="usa-button-primary" href="/track-claims">Track the status of your claim</a>
 
 <span id="days-to-complete-claim"></span>
 ### How long does it take VA to make a decision?

--- a/pages/education/about-gi-bill-benefits.md
+++ b/pages/education/about-gi-bill-benefits.md
@@ -73,7 +73,7 @@ If you applied for and were awarded Post-9/11 GI Bill education benefits, your G
 The GI Bill Comparison Tool and Veterans Service Organizations can help you explore options and find out what benefits you can get. [Find a Veterans service organization](https://www.va.gov/vso/).
 
 
-<a class="usa-button-primary va-button-secondary" href="/gi-bill-comparison-tool">Use the GI Bill Comparison Tool</a> <a class="usa-button-primary va-button-primary" href="/education/how-to-apply/">Apply for Education Benefits</a><br>
+<a class="usa-button-primary va-button-secondary" href="/gi-bill-comparison-tool">Use the GI Bill Comparison Tool</a> <a class="usa-button-primary va-button-primary" href="/education/how-to-apply/">Apply for education benefits</a><br>
 
 </div>
 

--- a/pages/education/how-to-apply.md
+++ b/pages/education/how-to-apply.md
@@ -110,7 +110,7 @@ You can work with a trained professional called an accredited representative to 
 You can’t make changes to your application, but if you have questions about VA education benefits, please call 888-GI-BILL-1 (<a href="tel:+18884424551">888-442-4551</a>), Monday through Friday, 8:00 a.m. to 7:00 p.m. <abbr title="eastern time">ET</abbr>.
 
 If we’ve asked you for documents, please upload them through the GI Bill website.
-<a class="usa-button-primary" href="https://gibill.custhelp.com/app/home">Go to the GI Bill Website</a>
+<a class="usa-button-primary" href="https://gibill.custhelp.com/app/home">Go to the GI Bill website</a>
 
 </div>
 </div>

--- a/pages/housing-assistance/disability-housing-grants.md
+++ b/pages/housing-assistance/disability-housing-grants.md
@@ -80,5 +80,5 @@ You can apply online right now by going to our eBenefits website.
 
 You’ll need to sign in to eBenefits with your <b>DS Logon</b> basic or premium account. If you don’t have a <b>DS Logon</b> account, you can register for one on the site.
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=sah-grant">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=sah-grant">Go to eBenefits to apply</a>
 

--- a/pages/housing-assistance/disability-housing-grants/how-to-apply.md
+++ b/pages/housing-assistance/disability-housing-grants/how-to-apply.md
@@ -4,7 +4,7 @@ template: detail-page
 title: How To Apply For A Specially Adapted Housing Grant
 heading: How to apply for a Specially Adapted Housing Grant
 display_title: How to apply
-description: Find out how to apply for a Specially Adapted Housing (SAH) grant or a Special Home Adaptation (SHA) grant. These grants offer financial help so you can make changes to your home to live more independently with a service-connected disability. 
+description: Find out how to apply for a Specially Adapted Housing (SAH) grant or a Special Home Adaptation (SHA) grant. These grants offer financial help so you can make changes to your home to live more independently with a service-connected disability.
 keywords: specially adapted housing grant, sah grant
 concurrence:
 order: 1
@@ -13,13 +13,13 @@ order: 1
 
 <div itemscope itemtype ="http://schema.org/HowTo">
 <div class="va-introtext" itemprop="description">
- 
+
 Find out how to apply for a Specially Adapted Housing (SAH) or Special Home Adaptation (SHA) grant on our eBenefits website. You can also check the status of an open SAH claim on the site.
 
 </div>
 
 <div class="feature">
- 
+
  ## How do I prepare before starting my application?
 
 <ul>
@@ -45,7 +45,7 @@ You can apply online right now by going to our eBenefits website.
 
 You’ll need to sign in to eBenefits with your <b>DS Logon</b> basic or premium account. If you don’t have a <b>DS Logon</b> account, you can register for one on the site.
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=sah-grant">Go to eBenefits to Apply</a></div>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=sah-grant">Go to eBenefits to apply</a></div>
 </div>
 
 <div itemprop="steps" itemscope itemtype ="http://schema.org/HowToSection">

--- a/pages/housing-assistance/home-loans/eligibility.md
+++ b/pages/housing-assistance/home-loans/eligibility.md
@@ -79,7 +79,7 @@ You may be able to get a COE if you didn't receive a dishonorable discharge and 
 
 You can apply online right now.
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=cert-of-eligibility-home-loan">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=cert-of-eligibility-home-loan">Go to eBenefits to apply</a>
 
 [Learn more about how to apply for your COE](/housing-assistance/home-loans/how-to-apply/)
 

--- a/pages/housing-assistance/home-loans/how-to-apply.md
+++ b/pages/housing-assistance/home-loans/how-to-apply.md
@@ -123,7 +123,7 @@ If you're a **discharged member of the Reserves** and were **never activated**, 
 
 You can apply online right now.
 
-<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=cert-of-eligibility-home-loan" target="_blank">Go to eBenefits to Apply</a>
+<a class="usa-button-primary va-button-primary" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=cert-of-eligibility-home-loan" target="_blank">Go to eBenefits to apply</a>
 
 #### You can also apply:
 

--- a/pages/pension/eligibility.md
+++ b/pages/pension/eligibility.md
@@ -4,8 +4,8 @@ template: detail-page
 title: Eligibility For Veterans Pension
 heading: Eligibility for Veterans Pension
 display_title: Eligibility
-description: The Veterans Pension program provides monthly payments to wartime Veterans based on need. Review VA pension eligibility requirements to find out if you qualify based on your age or a permanent and total non-service-connected disability, as well as your income and net worth. 
-keywords: veterans pension, non service connected pension, non service connected pension eligibility, va pension eligibility 
+description: The Veterans Pension program provides monthly payments to wartime Veterans based on need. Review VA pension eligibility requirements to find out if you qualify based on your age or a permanent and total non-service-connected disability, as well as your income and net worth.
+keywords: veterans pension, non service connected pension, non service connected pension eligibility, va pension eligibility
 concurrence:
 order: 1
 children: pensionEligibility
@@ -29,9 +29,9 @@ The Veterans Pension program provides monthly payments to wartime Veterans who m
 
 <div class="feature" markdown=“1”>
 
-### Am I eligible for Veterans Pension benefits from VA? 
+### Am I eligible for Veterans Pension benefits from VA?
 
-If you meet the VA pension eligibility requirements listed below, you may be eligible for the Veterans Pension program. 
+If you meet the VA pension eligibility requirements listed below, you may be eligible for the Veterans Pension program.
 
 **Both of these must be true:**
 
@@ -55,7 +55,7 @@ If you meet the VA pension eligibility requirements listed below, you may be eli
 
 </div>
 
-## How do I know if I served under an eligible wartime period? 
+## How do I know if I served under an eligible wartime period?
 Under current law, we recognize the following wartime periods to decide eligibility for VA pension benefits:
 
 
@@ -87,7 +87,7 @@ If you've received one of these discharge statuses, you may not be eligible for 
     </span>
   </div>
   <span class="static-widget-content vads-u-display--none" aria-hidden="true">
-    <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
+    <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans pension benefits</a>
   </span>
   <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
     <div class="usa-alert-body">

--- a/pages/pension/how-to-apply.md
+++ b/pages/pension/how-to-apply.md
@@ -57,7 +57,7 @@ Find out how to apply for tax-free VA pension benefits as a Veteran.
     </span>
   </div>
   <span class="static-widget-content vads-u-display--none" aria-hidden="true">
-    <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans Pension Benefits</a>
+    <a class="usa-button-primary va-button-primary" href="/pension/application/527EZ">Apply for Veterans pension benefits</a>
   </span>
   <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
     <div class="usa-alert-body">

--- a/pages/va-payment-history.md
+++ b/pages/va-payment-history.md
@@ -24,7 +24,7 @@ Find out how to view your VA payment history online.
     <h4 class="usa-alert-heading">You’ll need to sign in to eBenefits to view your payment history.</h4>
   <p class="usa-alert-text"><br>
     To use this feature, you'll need a Premium <b>DS Logon</b> account. Your My HealtheVet or ID.me credentials won’t work on the eBenefits website. Go to eBenefits to sign in, register, or upgrade your <b>DS Logon</b> account to Premium.<br>
-      <a class="usa-button-primary" target="_blank" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=payment-history">Go to eBenefits to View Payments</a>
+      <a class="usa-button-primary" target="_blank" href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=payment-history">Go to eBenefits to view payments</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Ticket - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18996

This PR updates the sentence casing for buttons across the website. A few are React component, and are being worked on this [vets-website PR](https://github.com/department-of-veterans-affairs/vets-website/pull/10292), but most are here in vagov-content.

I'm not a content editor myself, so I'm not the right person to make these changes. I quickly identified instances of HTML buttons by doing a text search for `usa-button` and then checking the letter case of the text, but I don't know if I updated each correctly or I missed anything. A content editor should own this from here.

These two buttons are in Drupal content, should be updated in Drupal -

/health-care/about-va-health-benefits/dental-care/
/health-care/order-hearing-aid-batteries-prosthetic-socks/
