### PR TITLE
Updated post-9-11.md webpage

### DIFF
--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -191,11 +191,11 @@ Previously, GI Bill beneficiaries were paid Monthly Housing Allowance (MHA) base
 
 Now, the MHA is based on the campus location where the student physically attends the majority of his or her classes.
 
-**The VA defines a campus as one of the following:**
+The VA defines a campus as one of the following:
 
-- **Main campus:** A location where the primary teaching facilities of an educational institution are located.
-- **Branch campus:** A location of an educational institution that is geographically apart from and operationally independent of the main campus of the educational institution.
-- **Extension campus:** A location that is geographically apart from the main or branch campus but is operationally dependent on that campus for the performance of administrative tasks. <br>
+- Main campus: A location where the primary teaching facilities of an educational institution are located.
+- Branch campus: A location of an educational institution that is geographically apart from and operationally independent of the main campus of the educational institution.
+- Extension campus: A location that is geographically apart from the main or branch campus but is operationally dependent on that campus for the performance of administrative tasks. <br>
 
 <h2 itemprop="name">Get more information</h2>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -183,7 +183,7 @@ You can use your GI Bill benefits in many ways to advance your education and tra
 
 <div itemscope itemtype="http://schema.org/Question">
 
-<h2 temprop="name" id="location-based">What is the Location-Based Housing Allowance (Section 107)?</h2>
+<h2 temprop="name">What is the Location-Based Housing Allowance (Section 107)?</h2>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -187,7 +187,7 @@ You can use your GI Bill benefits in many ways to advance your education and tra
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 
-Previously, GI Bill beneficiaries were paid a monthly housing allowance (MHA) based on the main or branch campus of the school they were enrolled in. If a student attended classes at more than one location, they were paid the rate that was most advantageous.<br>
+Previously, GI Bill beneficiaries were paid a monthly housing allowance (MHA) based on the main or branch campus of the school they were enrolled. If a student attended classes at more than one location, they were paid the rate that was most advantageous.<br>
 
 Now, the MHA is based on the campus location where the student physically attends the majority of his or her classes.
 

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -183,7 +183,7 @@ You can use your GI Bill benefits in many ways to advance your education and tra
 
 <div itemscope itemtype="http://schema.org/Question">
 
-<div id="location-based"><h2 itemprop="name">What is the Location-Based Housing Allowance (Section 107)?</h2></div>
+<div id="location-based107"><h2 itemprop="name">What is the Location-Based Housing Allowance (Section 107)?</h2></div>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -184,6 +184,20 @@ You can use your GI Bill benefits in many ways to advance your education and tra
 
 <div itemscope itemtype="http://schema.org/Question">
 
+<h2 id="location-based "itemprop="name">What is the Location-Based Housing Allowance (Section 107)?</h2>
+<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
+<div itemprop="text">
+
+Previously, GI Bill beneficiaries were paid Monthly Housing Allowance (MHA) based on the main or branch campus of the school they were enrolled. If a student attended classes at more than one location, they were paid the rate that was most advantageous.<br>
+
+Now, the MHA is based on the campus location where the student physically attends the majority of his or her classes.
+
+**The VA defines a campus as one of the following:**
+
+- **Main campus:** A  location where the primary teaching facilities of an educational institution are located.
+- **Branch campus:** A location of an educational institution that is geographically apart from and operationally independent of the main campus of the educational institution.
+- **Extension campus:** A location that is geographically apart from the main or branch campus but is operationally dependent on that campus for the performance of administrative tasks. <br>
+
 <h2 itemprop="name">Get more information</h2>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -183,7 +183,7 @@ You can use your GI Bill benefits in many ways to advance your education and tra
 
 <div itemscope itemtype="http://schema.org/Question">
 
-<h2 temprop="name">What is the Location-Based Housing Allowance (Section 107)?</h2>
+<h2 itemprop="name" id="location-based">What is the Location-Based Housing Allowance (Section 107)?</h2>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -195,7 +195,7 @@ The VA defines a campus as one of the following:
 
 - Main campus: A location where the primary teaching facilities of an educational institution are located
 - Branch campus: A location of an educational institution that is geographically apart from and operationally independent of the main campus of the educational institution
-- Extension campus: A location that is geographically apart from the main or branch campus but is operationally dependent on that campus for the performance of administrative tasks. <br>
+- Extension campus: A location that is geographically apart from the main or branch campus but is operationally dependent on that campus for the performance of administrative tasks <br>
 
 <h2 itemprop="name">Get more information</h2>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -183,7 +183,7 @@ You can use your GI Bill benefits in many ways to advance your education and tra
 
 <div itemscope itemtype="http://schema.org/Question">
 
-<h2 itemprop="name" id="location-based">What is the Location-Based Housing Allowance (Section 107)?</h2>
+<div id="location-based"><h2 itemprop="name">What is the Location-Based Housing Allowance (Section 107)?</h2></div>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -63,16 +63,16 @@ You’ll have to pick which benefit you'd like to use. This is an irrevocable de
 **You can receive up to 36 months of benefits, including:**
 
 - **Tuition and fees.** If you qualify for the maximum benefit, we'll cover the full cost of public, in-state tuition and fees. We cap the rates for private and foreign schools, and update those rates each year.<br>
-[ View current rates](https://www.benefits.va.gov/GIBILL/resources/benefits_resources/rates/ch33/ch33rates080118.asp)
+  [ View current rates](https://www.benefits.va.gov/GIBILL/resources/benefits_resources/rates/ch33/ch33rates080118.asp)
 - **Money for housing (if you're in school more than half time).** We'll base your monthly housing allowance on the cost of living where your school is located.
-- **Money for books and supplies.** You can receive up to $1,000 per school year.
-- **Money to help you move from a rural area to go to school.** You may qualify for this one-time payment of $500 if you live in a county with 6 or fewer people per square mile and you're either moving at least 500 miles to go to school or have no other option but to fly by plane to get to your school.
+- **Money for books and supplies.** You can receive up to \$1,000 per school year.
+- **Money to help you move from a rural area to go to school.** You may qualify for this one-time payment of \$500 if you live in a county with 6 or fewer people per square mile and you're either moving at least 500 miles to go to school or have no other option but to fly by plane to get to your school.
 
 **Here's how we'll determine how much of the benefit you'll qualify for:**
 
 The specific amount you'll receive will depend on how much active service you’ve had since September 10, 2001. We'll calculate this amount based on a percentage of the maximum benefit.
 
-**For example:** If you had 90 days of active service since September 10, 2001, you would qualify for 40% of the maximum amount. If you served for 3 years, you would qualify for 100% of the benefit. So if your school charges $22,000 for in-state tuition and fees, you would receive $8,800 if you had 90 days of active service and the full $22,000 if you had 3 years of active service.
+**For example:** If you had 90 days of active service since September 10, 2001, you would qualify for 40% of the maximum amount. If you served for 3 years, you would qualify for 100% of the benefit. So if your school charges $22,000 for in-state tuition and fees, you would receive $8,800 if you had 90 days of active service and the full \$22,000 if you had 3 years of active service.
 
 Note that this will change August 1, 2020. In this example, 90 days of active service would qualify you for 50% of the maximum amount as of August 1, 2020.
 
@@ -97,7 +97,7 @@ This depends on when you were discharged from active duty.
 </div>
 </div>
 
--------
+---
 
 <div itemscope itemtype="http://schema.org/Question">
 
@@ -135,11 +135,11 @@ If you already applied for and were awarded Post-9/11 GI Bill education benefits
 **You may qualify for these additional benefits:**
 
 - If you need more money to cover higher private-school or out-of-state tuition, you can apply for the Yellow Ribbon Program. <br>
-[Learn about the Yellow Ribbon Program](/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/)
+  [Learn about the Yellow Ribbon Program](/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/)
 - If you’re a qualified service member, you can transfer all 36 months or a portion of your Post-9/11 GI Bill benefits to a spouse or child. The Department of Defense approves a transfer of benefits. <br>
-[Learn about transferring Post-9/11 GI Bill benefits](/education/transfer-post-9-11-gi-bill-benefits/)
+  [Learn about transferring Post-9/11 GI Bill benefits](/education/transfer-post-9-11-gi-bill-benefits/)
 - If you're the child or surviving spouse of a service member who died in the line of duty after September 10, 2001, you may qualify for the Marine Gunnery Sergeant John David Fry Scholarship (Fry Scholarship). <br>
-[Learn more about the Fry Scholarship](/education/survivor-dependent-benefits/fry-scholarship/)
+  [Learn more about the Fry Scholarship](/education/survivor-dependent-benefits/fry-scholarship/)
 
 </div>
 </div>
@@ -177,14 +177,13 @@ You can use your GI Bill benefits in many ways to advance your education and tra
 - [Correspondence training](/education/about-gi-bill-benefits/how-to-use-benefits/correspondence-training/)
 - [Independent and distance learning](/education/about-gi-bill-benefits/how-to-use-benefits/online-distance-learning/)
 
-
 </div>
 </div>
 </div>
 
 <div itemscope itemtype="http://schema.org/Question">
 
-<h2 id="location-based "itemprop="name">What is the Location-Based Housing Allowance (Section 107)?</h2>
+<h2 temprop="name" id="location-based">What is the Location-Based Housing Allowance (Section 107)?</h2>
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 
@@ -194,7 +193,7 @@ Now, the MHA is based on the campus location where the student physically attend
 
 **The VA defines a campus as one of the following:**
 
-- **Main campus:** A  location where the primary teaching facilities of an educational institution are located.
+- **Main campus:** A location where the primary teaching facilities of an educational institution are located.
 - **Branch campus:** A location of an educational institution that is geographically apart from and operationally independent of the main campus of the educational institution.
 - **Extension campus:** A location that is geographically apart from the main or branch campus but is operationally dependent on that campus for the performance of administrative tasks. <br>
 
@@ -203,7 +202,7 @@ Now, the MHA is based on the campus location where the student physically attend
 <div itemprop="text">
 
 - Compare benefits by school. <br>
-[Use the GI Bill Comparison Tool](/gi-bill-comparison-tool)
+  [Use the GI Bill Comparison Tool](/gi-bill-comparison-tool)
 - [See the current payment rates for the Post-9/11 GI Bill](/education/benefit-rates/)
 - [Read the Post-9/11 GI Bill pamphlet (PDF)](https://www.benefits.va.gov/gibill/docs/pamphlets/ch33_pamphlet.pdf)
 - [See Frequently Asked Questions (FAQ)](https://gibill.custhelp.com/app/answers/list)

--- a/pages/education/about-gi-bill-benefits/post-9-11.md
+++ b/pages/education/about-gi-bill-benefits/post-9-11.md
@@ -187,14 +187,14 @@ You can use your GI Bill benefits in many ways to advance your education and tra
 <div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
 <div itemprop="text">
 
-Previously, GI Bill beneficiaries were paid Monthly Housing Allowance (MHA) based on the main or branch campus of the school they were enrolled. If a student attended classes at more than one location, they were paid the rate that was most advantageous.<br>
+Previously, GI Bill beneficiaries were paid a monthly housing allowance (MHA) based on the main or branch campus of the school they were enrolled in. If a student attended classes at more than one location, they were paid the rate that was most advantageous.<br>
 
 Now, the MHA is based on the campus location where the student physically attends the majority of his or her classes.
 
 The VA defines a campus as one of the following:
 
-- Main campus: A location where the primary teaching facilities of an educational institution are located.
-- Branch campus: A location of an educational institution that is geographically apart from and operationally independent of the main campus of the educational institution.
+- Main campus: A location where the primary teaching facilities of an educational institution are located
+- Branch campus: A location of an educational institution that is geographically apart from and operationally independent of the main campus of the educational institution
 - Extension campus: A location that is geographically apart from the main or branch campus but is operationally dependent on that campus for the performance of administrative tasks. <br>
 
 <h2 itemprop="name">Get more information</h2>


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/education/about-gi-bill-benefits/post-9-11/

## Origin of request (internal/stakeholder/user feedback)


## Description of what's needed (edits/link changes/additions)

1. A new section "What is the Location-Based Housing Allowance (Section 107)?" is displayed between the following sections on the page https://www.va.gov/education/about-gi-bill-benefits/post-9-11/ :
- "How can I use my Post-9/11 GI Bill benefits?"
- "Get more information"
2. The section title (What is the Location-Based Housing Allowance (Section 107)?) has an anchor tag so that external links can load the page with the section displayed.
3. The section has the following content:
"What is the Location-Based Housing Allowance (Section 107)?
Previously, GI Bill beneficiaries were paid Monthly Housing Allowance (MHA) based on the main or branch campus of the school they were enrolled. If a student attended classes at more than one location, they were paid the rate that was most advantageous.

Now, the MHA is based on the campus location where the student physically attends the majority of his or her classes.

The VA defines a campus as one of the following:

- Main campus: A location where the primary teaching facilities of an educational institution are located.
- Branch campus: A location of an educational institution that is geographically apart from and operationally independent of the main campus of the educational institution.
- Extension campus: A location that is geographically apart from the main or branch campus but is operationally dependent on that campus for the performance of administrative tasks."