### PR TITLE
Fix layout on detail pages not requiring the side nav

### DIFF
--- a/pages/privacy-policy.md
+++ b/pages/privacy-policy.md
@@ -3,6 +3,7 @@ layout: page-breadcrumbs.html
 template: detail-page
 title: Privacy, Policies, And Legal Information
 heading: Privacy, policies, and legal information
+hidesidenav: true
 ---
 
 <p class="va-introtext">

--- a/pages/veterans-portrait-project.md
+++ b/pages/veterans-portrait-project.md
@@ -6,10 +6,11 @@ heading: The Veterans Portrait Project on VA.gov
 display_title: Veterans Portrait Project
 description:
 concurrence:
+hidesidenav: true
 ---
 
 <div class="va-introtext">
-The images of U.S. Veterans that you see on the VA.gov homepage come from the Veterans Portrait Project, an initiative started by retired Air Force Staff Sergeant and Aerial Combat Photojournalist Stacy Pearsall to honor her fellow Veterans through photography.  
+The images of U.S. Veterans that you see on the VA.gov homepage come from the Veterans Portrait Project, an initiative started by retired Air Force Staff Sergeant and Aerial Combat Photojournalist Stacy Pearsall to honor her fellow Veterans through photography.
 </div>
 
 Pearsall has photographed more than 7,500 Veterans so far, and hopes to capture portraits of Veterans in every state and province the U.S. Department of Defense recruits from. She got the idea for the project after being injured in combat. “After spending hours in VA waiting rooms surrounded by Veterans from every generation and branch of service,” she says, “I was compelled to honor and thank them in the only way I know how: photography.”
@@ -17,7 +18,7 @@ Pearsall has photographed more than 7,500 Veterans so far, and hopes to capture 
 [Learn more about the Veterans featured on VA.gov](#veterans) <br>
 [Learn more about Stacy Pearsall, founder of the Veterans Portrait Project](#pearsall)
 
-<h2 id="veterans">Featured Veterans</h2> 
+<h2 id="veterans">Featured Veterans</h2>
 
 **VA.gov currently features Pearsall's images of these Veterans:**
 
@@ -50,7 +51,7 @@ Navy <br>
 Naval Flight Officer <br>
 May 1998 to the present <br>
 OEF, OSW <br>
- 
+
 **Bobby H.** <br>
 Army <br>
 88M Truck Driver <br>
@@ -75,9 +76,9 @@ Nurse <br>
 December 1985 to December 2010 <br>
 Desert Shield, Desert Storm, and Enduring Freedom <br>
 
-<h2 id="pearsall">More about Stacy Pearsall, founder of the Veterans Portrait Project</h2> 
+<h2 id="pearsall">More about Stacy Pearsall, founder of the Veterans Portrait Project</h2>
 
-Stacy L. Pearsall got her start as an Air Force photographer at age 17. During her time in service, she traveled to over 41 countries and attended the Military Photojournalism Program at S.I. Newhouse School of Public Communications at Syracuse University. During 3 combat tours, she earned the Bronze Star Medal and Air Force Commendation with Valor for combat actions in Iraq. 
+Stacy L. Pearsall got her start as an Air Force photographer at age 17. During her time in service, she traveled to over 41 countries and attended the Military Photojournalism Program at S.I. Newhouse School of Public Communications at Syracuse University. During 3 combat tours, she earned the Bronze Star Medal and Air Force Commendation with Valor for combat actions in Iraq.
 
 Though combat disabled and retired from military service, Pearsall continues to work around the world. With her service animal, America’s VetDogs Charlie, by her side, she works as an independent photographer represented by Aurora Photos. Her photographs have been exhibited at the Woodruff Arts Center, the Pentagon, the Smithsonian National Portrait Gallery, the National Veterans Memorial and Museum, and many other galleries and venues. In addition to her photography, Pearsall is also an author, educator, military consultant, BRAVO748 public speaker, and founder of the Veterans Portrait Project. She also serves as a Nikon and Manfrotto Ambassador and Ilford Master.
 

--- a/pages/welcome-kit.md
+++ b/pages/welcome-kit.md
@@ -6,6 +6,7 @@ display_title: Your VA Welcome Kit
 order: 1
 plainlanguage:
 template: detail-page
+hidesidenav: true
 majorlinks:
   - heading: Explore VA.gov to learn about your benefits
     links:


### PR DESCRIPTION
## Page to edit
url: 
  - /privacy-policy/
  - /veterans-portrait-project/
  - /welcome-kit/

## Origin of request (internal/stakeholder/user feedback)
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19169

## Description of what's needed (edits/link changes/additions)
These pages were missing `hidesidenav: true` in their frontmatter, causing them to render with empty whitespace on the left side. For example -

![image](https://user-images.githubusercontent.com/1915775/60832506-07cdd700-a18a-11e9-8002-efa7fbb13061.png)

This PR fixes that by adding `hidesidenav: true` to those pages.
