### PR TITLE
[MegaMenu] Remove the second column title from the Records section

### DIFF
--- a/fragments/megamenu/index.yml
+++ b/fragments/megamenu/index.yml
@@ -251,7 +251,8 @@
         - text: Get Veteran ID cards
           href: https://www.va.gov/records/get-veteran-id-cards/
       columnTwo:
-        title: Manage your records
+        # No title property for this section -
+        # https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17695
         links:
         - text: Request your military records (DD214)
           href: https://www.va.gov/records/get-military-service-records/


### PR DESCRIPTION
## Page to edit
url: site-wide

## Origin of request (internal/stakeholder/user feedback)
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17695

## Description of what's needed (edits/link changes/additions)
In the MegaMenu, under the Records tab of the VA Benefits and Health Care section, there is a column title that says `Manage your records`. This title should be omitted. This PR removes the title from the config. See image below.

These PR goes alongside the changes in this vets-website PR, https://github.com/department-of-veterans-affairs/vets-website/pull/10421.

![image](https://user-images.githubusercontent.com/1915775/61237600-d4022c80-a708-11e9-8bd1-60645d1c6dcb.png)

