### PR TITLE
Use cached CMS data to do Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,14 +91,15 @@ https://www.github.com/${GITHUB_ORG}/${CONTENT_REPO}/pull/${prNumber}
 
     def currentDir = pwd()
     def dockerArgs = "-v ${currentDir}/${APP_CODE_REPO}:/application -v ${currentDir}/${CONTENT_REPO}:/${CONTENT_REPO}"
-    def drupalAddress = "http://internal-prod-vagovcms-3001-2053888503.us-gov-west-1.elb.amazonaws.com"
 
     withCredentials([usernamePassword(credentialsId:  "drupal-prod", usernameVariable: 'DRUPAL_USERNAME', passwordVariable: 'DRUPAL_PASSWORD')]) {
       dockerImage.inside(dockerArgs) {
         def installDependencies = "cd /application && yarn install --production=false"
-        def build = "npm --prefix /application --no-color run build -- --buildtype=vagovprod --drupal-address=${drupalAddress} --entry static-pages --pull-drupal 2>&1 | tee output.log"
-
+        def getCachedCmsData = "node script/drupal-aws-cache.js --fetch --buildtype=vagovprod"
+        def build = "npm --prefix /application --no-color run build -- --buildtype=vagovprod --entry=static-pages 2>&1 | tee output.log"
+        
         sh installDependencies
+        sh getCachedCmsData
         sh build
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,7 @@ https://www.github.com/${GITHUB_ORG}/${CONTENT_REPO}/pull/${prNumber}
     withCredentials([usernamePassword(credentialsId:  "drupal-prod", usernameVariable: 'DRUPAL_USERNAME', passwordVariable: 'DRUPAL_PASSWORD')]) {
       dockerImage.inside(dockerArgs) {
         def installDependencies = "cd /application && yarn install --production=false"
-        def getCachedCmsData = "node script/drupal-aws-cache.js --fetch --buildtype=vagovprod"
+        def getCachedCmsData = "cd /application && node script/drupal-aws-cache.js --fetch --buildtype=vagovprod"
         def build = "npm --prefix /application --no-color run build -- --buildtype=vagovprod --entry=static-pages 2>&1 | tee output.log"
         
         sh installDependencies

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "vagov-apps:clone": "git clone --depth=1 https://github.com/department-of-veterans-affairs/vets-website ../vagov-apps",
-    "vagov-apps:install": "cd ../vagov-apps && yarn install --production=false",
-    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry static-pages --pull-drupal",
+    "vagov-apps:install": "cd ../vagov-apps && yarn install --production=false && node script/drupal-aws-cache.js --fetch --buildtype=vagovprod",
+    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry=static-pages",
     "move-output": "mv ../vagov-apps/build build",
     "preinstall": "npm run vagov-apps:clone && npm run vagov-apps:install && npm run vagov-apps:build && npm run move-output",
     "start": "http-server build/localhost"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "vagov-apps:clone": "git clone --depth=1 https://github.com/department-of-veterans-affairs/vets-website ../vagov-apps",
-    "vagov-apps:install": "cd ../vagov-apps && yarn install --production=false && node script/drupal-aws-cache.js --fetch --buildtype=vagovprod",
-    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry=static-pages",
+    "vagov-apps:install": "cd ../vagov-apps && yarn install --production=false",
+    "vagov-apps:build": "INSTALL_HOOKS=no npm --prefix ../vagov-apps run build -- --content-directory=${PWD}/pages --entry static-pages --pull-drupal",
     "move-output": "mv ../vagov-apps/build build",
     "preinstall": "npm run vagov-apps:clone && npm run vagov-apps:install && npm run vagov-apps:build && npm run move-output",
     "start": "http-server build/localhost"


### PR DESCRIPTION
## Page to edit
N/A

## Origin of request (internal/stakeholder/user feedback)
CMS Prod errors cause PRs here to fail. Using the cached CMS data from S3 should resolve this.

## Description of what's needed (edits/link changes/additions)
The cached CMS data on S3 is used during vets-website builds if the latest data from the CMS results in a build error. vagov-content doesn't have this step, so a fail results in a PR that cannot be merged. This PR fixes that by using the cache.
