### PR TITLE
[Education] Add "Not a Veteran?" section to right rail

### DIFF
--- a/pages/education/index.md
+++ b/pages/education/index.md
@@ -58,6 +58,12 @@ social:
           title: "Call MyVA311 for help:"
         - url:
           title: "If you have hearing loss, call TTY: 711."
+  - heading: Not a Veteran?
+    subsections:
+      - subhead: "Get education and training information for:"
+        links:
+        - url: https://www.benefits.va.gov/gibill/school_resources.asp
+          label: School administrators
   - heading: Connect with us
     admin: Veterans Benefits Administration
     url: https://www.benefits.va.gov/benefits/


### PR DESCRIPTION
## Page to edit
url: /education

## Origin of request (internal/stakeholder/user feedback)
https://github.com/department-of-veterans-affairs/vagov-content/issues/507

## Description of what's needed (edits/link changes/additions)
Add "Not a Veteran?" section to right rail

![image](https://user-images.githubusercontent.com/1915775/61665505-27ddba00-aca3-11e9-901c-01b91d61c4c1.png)

