### PR TITLE
Fix schema.org markup on flight training page

### DIFF
--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/flight-training.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/flight-training.md
@@ -87,7 +87,10 @@ You can get qualifications, including:
 - Dual engine
 - Flight engineer
 
+</div>
+
 -----
+
 
 <div itemscope itemtype="http://schema.org/Question">
 <h2 itemprop="name">How do I get these benefits?</h2>
@@ -97,7 +100,6 @@ You can get qualifications, including:
 You’ll need to apply for benefits. <br>
 [Apply for education benefits](/education/how-to-apply/)
 
-</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/education/about-gi-bill-benefits/how-to-use-benefits/flight-training/

## Origin of request (internal/stakeholder/user feedback)
Bad schema.org markup

## Description of what's needed (edits/link changes/additions)

Just markup change, should look the same on the front end

Compare URL above to https://vagov-content-pr-515.herokuapp.com/education/about-gi-bill-benefits/how-to-use-benefits/flight-training/