### PR TITLE
Add missing </div></div> to help migration script parse the page.

### DIFF
--- a/pages/burials-memorials/veterans-burial-allowance.md
+++ b/pages/burials-memorials/veterans-burial-allowance.md
@@ -123,6 +123,8 @@ Mail the application and other documents listed above to your nearest VA regiona
 [Find your nearest VA regional benefit office](/find-locations/?facilityType=benefits)
 
 If you have questions, call <a href="tel:+1-800-827-1000">800-827-1000</a>. We're here Monday through Friday, 8:00 a.m. to 9:00 p.m. <abbr title="eastern time">ET</abbr>. Our TTY number for people with hearing impairments is 711. Or call your VA regional benefit office.
+</div>
+</div>
 
 ------
 ## Burial allowance amounts


### PR DESCRIPTION
## Page to edit
url: https://vagov-content-pr-137.herokuapp.com/burials-memorials/veterans-burial-allowance/

## Origin of request (internal/stakeholder/user feedback)

The schema.org/howto includes a ton of QAs, and we think that's causing the migration script to choke. 

## Description of what's needed (edits/link changes/additions)
I've added two missing `</div>s` where i think they belong 
