### PR TITLE
Content-removing-VET-TEC-provider-chart

### DIFF
--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program.md
@@ -73,15 +73,10 @@ If we determine that you're eligible for VET TEC, you'll then apply to the VA-ap
 
 ## VET TEC training providers
 
-See your options for training providers listed below. A provider is considered "preferred" if the training facility agrees to refund tuition and fees if a student doesn't find meaningful employment within 180 days of completing the program.  
+To see the list of VA-approved training providers, go to the [GI Bill Comparison Tool](https://www.va.gov/gi-bill-comparison-tool/search?vetTecProvider=true). 
 
-| **Provider name** | **Address** | **Program name** | **Program length** | **Type of training** | **Preferred training provider** | 
-|---|---|---|---|---|---|
-| [Skill Distillery](https://skilldistillery.com/) | 7400 E. Orchard Road, Suite 1450N, Greenwood Village, CO 80111  | Full Stack Development with Java | 680 hours | In person | Yes |
-| [Zip Code Wilmington](https://www.zipcodewilmington.com) | 1007 N. Orange Street, 4th floor, Wilmington, DE 19801  | Software Development Bootcamp | 480 Hours | In person | No |
-| [Code Platoon](https://www.codeplatoon.org/) | 125 S. Clark Street, 17th floor, Chicago, IL 60603 | Code Platoon | 560 hours | In person and online | No |
-| [Detroit School for Digital Technology](https://www.dsdt.tech/) | 1759 W. 20th Street, Detroit, MI 48216 | Technology Professional 2 | 80 hours | In person | No |
-|  [Detroit School for Digital Technology](https://www.dsdt.tech/) | 1759 W. 20th Street, Detroit, MI 48216 | Technology Professional 6 | 240 hours | In person | No |
+A provider is considered "preferred" if the training facility agrees to refund tuition and fees if a student doesn't find meaningful employment within 180 days of completing the program.
+
 
 ## How can I show that I've completed the program?
 

--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program.md
@@ -73,7 +73,7 @@ If we determine that you're eligible for VET TEC, you'll then apply to the VA-ap
 
 ## VET TEC training providers
 
-To see the list of VA-approved VET TEC training providers, go to the [GI Bill Comparison Tool](https://www.va.gov/gi-bill-comparison-tool/). 
+Browse the [list of VA-approved VET TEC training providers](https://www.benefits.va.gov/GIBILL/FGIB/VetTecTrainingProviders.asp).
 
 A provider is considered "preferred" if the training facility agrees to refund tuition and fees if a student doesn't find meaningful employment within 180 days of completing the program.
 

--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program.md
@@ -73,7 +73,7 @@ If we determine that you're eligible for VET TEC, you'll then apply to the VA-ap
 
 ## VET TEC training providers
 
-To see the list of VA-approved training providers, go to the [GI Bill Comparison Tool](https://www.va.gov/gi-bill-comparison-tool/search?vetTecProvider=true). 
+To see the list of VA-approved VET TEC training providers, go to the [GI Bill Comparison Tool](https://www.va.gov/gi-bill-comparison-tool/). 
 
 A provider is considered "preferred" if the training facility agrees to refund tuition and fees if a student doesn't find meaningful employment within 180 days of completing the program.
 


### PR DESCRIPTION
## Page to edit
https://www.va.gov/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/

## Origin of request (internal/stakeholder/user feedback)
Stakeholder request, per weekly DSVA-EDU call. 

## Description of what's needed (edits/link changes/additions)
The VET TEC provider chart needs to be removed from the page. We need to direct users to: https://www.benefits.va.gov/GIBILL/FGIB/VetTecTrainingProviders.asp to see the list of VA-approved training providers. 

