### PR TITLE
[MegaMenu] Update title for link to "About VA"

### DIFF
--- a/fragments/megamenu/index.yml
+++ b/fragments/megamenu/index.yml
@@ -317,7 +317,7 @@
     columnTwo:
       title: Learn about VA
       links:
-      - text: VA mission, vision, and values
+      - text: About VA
         href: https://www.va.gov/ABOUT_VA/index.asp
       - text: History of VA
         href: https://www.va.gov/about_va/vahistory.asp


### PR DESCRIPTION
## Page to edit
url: site-wide

## Origin of request (internal/stakeholder/user feedback)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/729

## Description of what's needed (edits/link changes/additions)
Update title of About VA link to be clearer that it's an "about us" page
