### PR TITLE
Update GitHub code owners config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-/fragments/home/banner.yml @department-of-veterans-affairs/frontend-review-group
-/fragments/home/news.yml @department-of-veterans-affairs/frontend-review-group
+/fragments/home/banner.yml @department-of-veterans-affairs/frontend-review-group @ncksllvn
+/fragments/home/news.yml @department-of-veterans-affairs/frontend-review-group @ncksllvn

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 /fragments/home/banner.yml @department-of-veterans-affairs/frontend-review-group
+/fragments/home/news.yml @department-of-veterans-affairs/frontend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/pages/ @bethpotts @DanielleSoCompany @peggygannon
+/fragments/home/banner.yml @department-of-veterans-affairs/frontend-review-group


### PR DESCRIPTION
This PR updates the GitHub code owners to:

- Stop notifying former team members 😞 (hope you all return)
- Notify FE engineering group when a request to publish a homepage banner comes through.