### PR TITLE
Fix adding missing /div tags that break migration.

### DIFF
--- a/pages/education/about-gi-bill-benefits/how-to-use-benefits/flight-training.md
+++ b/pages/education/about-gi-bill-benefits/how-to-use-benefits/flight-training.md
@@ -88,6 +88,8 @@ You can get qualifications, including:
 - Flight engineer
 
 </div>
+</div>
+</div>
 
 -----
 
@@ -100,6 +102,7 @@ You can get qualifications, including:
 You’ll need to apply for benefits. <br>
 [Apply for education benefits](/education/how-to-apply/)
 
+</div>
 </div>
 </div>
 </div>


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/education/about-gi-bill-benefits/how-to-use-benefits/flight-training/

## Origin of request (internal/stakeholder/user feedback)

Missing /div's are causing malformed schema.org markup, causing migration to fail. 

## Description of what's needed (edits/link changes/additions)
MOAR /div's!
