### PR TITLE
[Banner] Change format of multiline string in YML file

### DIFF
--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -24,7 +24,7 @@ type: warning
 title: Hurricane Dorian
 content: '
     <p>NIck test</p>
-    <strong>testing</strong>    
+    <strong>testing again again again</strong>    
     <p>For the latest on how Hurricane Dorian is affecting VA facilities in the <strong>Sunshine Healthcare Network</strong> and the <strong>Caribbean Healthcare System</strong>, <a href="https://www.visn8.va.gov/VISN8/emergency/index.asp">visit our website</a> for facility updates, pharmacy and counseling information.</p>
 
     <p>Veterans who have questions may also contact the Veteran Disaster Hotline at <a href="tel:18005074571">800-507-4571</a>.</p>

--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -12,21 +12,19 @@
 # visible: false
 # type: warning
 # title: Some VA.gov tools and features may not be working as expected
-# content: '
+# content: >--
 #     We’re sorry. We’re working to fix some problems with DS Logon right now.
 #     Please check back later or call MyVA311 for help: <a href="tel:18446982311">1-844-698-2311</a>.
 #     If you have hearing loss, call TTY: 711.
-#   '
 #
 
 visible: true
 type: warning
 title: Hurricane Dorian
-content: '
+content: >--
     <p>NIck test</p>
     <p>For the latest on how Hurricane Dorian is affecting VA facilities in the <strong>Sunshine Healthcare Network</strong> and the <strong>Caribbean Healthcare System</strong>, <a href="https://www.visn8.va.gov/VISN8/emergency/index.asp">visit our website</a> for facility updates, pharmacy and counseling information.</p>
 
     <p>Veterans who have questions may also contact the Veteran Disaster Hotline at <a href="tel:18005074571">800-507-4571</a>.</p>
 
     <p>VA Employees impacted by the storm can contact the Employee Disaster Response Line at <a href="tel:18662330152">866-233-0152</a> to report their status and to obtain resource information.</p>
-   '

--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -23,6 +23,7 @@ visible: true
 type: warning
 title: Hurricane Dorian
 content: '
+    <p>NIck test</p>
     <p>For the latest on how Hurricane Dorian is affecting VA facilities in the <strong>Sunshine Healthcare Network</strong> and the <strong>Caribbean Healthcare System</strong>, <a href="https://www.visn8.va.gov/VISN8/emergency/index.asp">visit our website</a> for facility updates, pharmacy and counseling information.</p>
 
     <p>Veterans who have questions may also contact the Veteran Disaster Hotline at <a href="tel:18005074571">800-507-4571</a>.</p>

--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -12,7 +12,7 @@
 # visible: false
 # type: warning
 # title: Some VA.gov tools and features may not be working as expected
-# content: >--
+# content: |
 #     We’re sorry. We’re working to fix some problems with DS Logon right now.
 #     Please check back later or call MyVA311 for help: <a href="tel:18446982311">1-844-698-2311</a>.
 #     If you have hearing loss, call TTY: 711.
@@ -21,7 +21,7 @@
 visible: true
 type: warning
 title: Hurricane Dorian
-content: >--
+content: |
     <p>NIck test</p>
     <p>For the latest on how Hurricane Dorian is affecting VA facilities in the <strong>Sunshine Healthcare Network</strong> and the <strong>Caribbean Healthcare System</strong>, <a href="https://www.visn8.va.gov/VISN8/emergency/index.asp">visit our website</a> for facility updates, pharmacy and counseling information.</p>
 

--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -24,6 +24,7 @@ type: warning
 title: Hurricane Dorian
 content: '
     <p>NIck test</p>
+    <script>alert('hey')</script>
     <p>For the latest on how Hurricane Dorian is affecting VA facilities in the <strong>Sunshine Healthcare Network</strong> and the <strong>Caribbean Healthcare System</strong>, <a href="https://www.visn8.va.gov/VISN8/emergency/index.asp">visit our website</a> for facility updates, pharmacy and counseling information.</p>
 
     <p>Veterans who have questions may also contact the Veteran Disaster Hotline at <a href="tel:18005074571">800-507-4571</a>.</p>

--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -24,7 +24,6 @@ type: warning
 title: Hurricane Dorian
 content: '
     <p>NIck test</p>
-    <strong>testing again again again</strong>    
     <p>For the latest on how Hurricane Dorian is affecting VA facilities in the <strong>Sunshine Healthcare Network</strong> and the <strong>Caribbean Healthcare System</strong>, <a href="https://www.visn8.va.gov/VISN8/emergency/index.asp">visit our website</a> for facility updates, pharmacy and counseling information.</p>
 
     <p>Veterans who have questions may also contact the Veteran Disaster Hotline at <a href="tel:18005074571">800-507-4571</a>.</p>

--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -24,7 +24,7 @@ type: warning
 title: Hurricane Dorian
 content: '
     <p>NIck test</p>
-    <script>alert('hey')</script>
+    <strong>testing</strong>    
     <p>For the latest on how Hurricane Dorian is affecting VA facilities in the <strong>Sunshine Healthcare Network</strong> and the <strong>Caribbean Healthcare System</strong>, <a href="https://www.visn8.va.gov/VISN8/emergency/index.asp">visit our website</a> for facility updates, pharmacy and counseling information.</p>
 
     <p>Veterans who have questions may also contact the Veteran Disaster Hotline at <a href="tel:18005074571">800-507-4571</a>.</p>

--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -22,7 +22,6 @@ visible: true
 type: warning
 title: Hurricane Dorian
 content: |
-    <p>NIck test</p>
     <p>For the latest on how Hurricane Dorian is affecting VA facilities in the <strong>Sunshine Healthcare Network</strong> and the <strong>Caribbean Healthcare System</strong>, <a href="https://www.visn8.va.gov/VISN8/emergency/index.asp">visit our website</a> for facility updates, pharmacy and counseling information.</p>
 
     <p>Veterans who have questions may also contact the Veteran Disaster Hotline at <a href="tel:18005074571">800-507-4571</a>.</p>


### PR DESCRIPTION
We are currently using `'` to wrap the multiline content string. This PR switches that to use a `|` because it's unlikely that a `|` will be needed in the content, reducing the risk of a syntax error.