### PR TITLE
Fixing subway map anomaly

### DIFF
--- a/pages/disability/about-disability-ratings.md
+++ b/pages/disability/about-disability-ratings.md
@@ -1,58 +1,346 @@
 ---
 layout: page-breadcrumbs.html
-title: How VA Assigns Disability Ratings
-heading: How VA assigns disability ratings
-display_title: About disability ratings
-description: Learn about VA disability ratings and how we decide your rating. Plus, get a link to the VA disability rating chart, called the combined ratings table, which shows how we calculate disability rating percentages for Veterans with more than one service-connected condition.
+title: About VA Disability Ratings | Veterans Affairs
+display_title: About Disability Ratings
+heading: About VA disability ratings
+description: Learn about VA disability ratings and how we assign your rating. And view the VA disability rating chart, called the Combined Ratings table, which shows how we calculate disability rating percentages for Veterans with more than one service-connected condition. 
+keywords: va disability ratings, va disability rating chart, va disability percentages for conditions, va disability rating
 template: detail-page
 order: 1
+aliases:
+  - /disability-benefits/eligibility/ratings/
 spoke: More resources
 children: disabilityAboutRatings
+
 ---
+<div itemscope itemtype="http://schema.org/FAQPage">
 <div class="va-introtext">
 
-Find out how we determine your disability rating.
+Learn about VA disability ratings and how we assign your rating. If you have more than one service-connected condition, use our VA disability rating chart (called the combined ratings table) to find out how we'll determine your combined disability rating.
 
 </div>
 
-## What is a disability rating?
+<h3>On this page</h3>
+- [How we assign VA disability ratings](#assign)
+- [How we determine combined VA disability ratings](#combined)
 
-We assign you a disability rating based on the severity of your disability. We use this rating to determine your compensation rate.
+------
+<span id="assign"></a>
+<h2>How we assign VA disability ratings</h2>
 
+<div itemscope itemtype="http://schema.org/Question">
 
-## What does VA use to decide my disability rating?
+<h3 itemprop="name">What is a VA disability rating?</h3>
+<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
+<div itemprop="text">
 
-We base your rating on:
+We assign you a disability rating based on the severity of your disability. We express this rating as a percentage, representing how much your disability decreases your overall health and ability to function.
 
-- The evidence you give us (like a doctor’s report or medical test results), **and**
-- The results of your VA claim (C&P) exam (if we determine you need this exam), **and**
-- Other information we may get from other sources (like federal agencies)
+We then use your disability rating to determine your disability compensation rate, so we can calculate how much money you’ll receive from us each month. We also use your disability rating to help determine your eligibility for other benefits, like VA health care.
 
-If you have more than one disability, we use a combined ratings table to calculate your disability percentage. <br>
-[View the combined ratings table](https://www.benefits.va.gov/COMPENSATION/rates-index.asp#combinedRatingsTable1)
+</div>
+</div>
+</div>
 
-To learn more about how disability ratings work, you can watch our video about how we decide your rating: <br>
-[Compensation 101: How did I get this rating?](https://www.youtube.com/watch?v=oM7oYzL2DCg)
+<div itemscope itemtype="http://schema.org/Question">
 
-## How do ratings work for a disability I had before entering the service that got worse because of my service?
+<h3 itemprop="name">What does VA use to decide my disability rating?</h3>
+<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
+<div itemprop="text">
 
-If you get disability benefits for a disability that you had before entering the military that got worse because of your service (called a preservice claim), the amount of compensation (monthly payments) you’ll get will be based on the level of aggravation, or how much worse your service made your disability.
+<strong>We base your rating on:</strong>
+<ul>
+  <li>The evidence you give us (like a doctor’s report or medical test results), <strong>and</strong></li>
+  <li>The results of your VA claim exam (also called a compensation and pension, or C&P, exam), if we determine you need this exam, <strong>and</strong></li>
+  <li>Other information we may get from other sources (like federal agencies)</li>
 
-For example, if you had an illness or injury (also known as a condition) that was 10% disabling when you entered the military, and it became 20% disabling due to service, then the level of aggravation would be 10%.
+</div>
+</div>
+</div>
 
-## Can I get increased payments if I have a severe disability or dependents?
+<div itemscope itemtype="http://schema.org/Question">
 
-Yes. We may increase your monthly payments if one or more of these is true for you. You have a:
+<h3 itemprop="name">What if I have more than one disability?</h3>
+<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
+<div itemprop="text">
 
-- Very severe disability or loss of limb, **or**
-- Spouse, child, or dependent parent and your combined disability is 30% or greater, **or**
-- Spouse with a serious disability
+We’ll use a method called the “whole person theory” to determine what we call your combined disability rating. We do this to make sure that your total VA disability rating doesn’t add up to more than 100%. That’s because a person can’t be more than 100% able-bodied. 
 
+Read below to find out more about how we’ll calculate your combined disability rating using our combined ratings table. <br>
+<a href="#combined">Go to the combined ratings table</a>
 
-## Is there anything else that might affect my compensation amount?
+</div>
+</div>
+</div>
 
-Yes. Your compensation may end up being less than it otherwise would be if either of these is true. You:
+<div itemscope itemtype="http://schema.org/Question">
 
-- Receive military retirement pay, disability severance pay, or separation pay
-- Are incarcerated in a federal, state, or local facility for more than 60 days for conviction of a felony
+<h3 itemprop="name">How do ratings work for a disability I had before entering the service that got worse because of my service?</h3>
+<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
+<div itemprop="text">
 
+If you get disability benefits for a preservice claim, we’ll base your monthly compensation amount on the level of aggravation. This means how much worse your disability got because of your service.
+
+<strong>For example:</strong> If you had an illness or injury (also known as a condition) that was rated as 10% disabling when you entered the military, and it became 20% disabling due to the effects of your service, then the level of aggravation would be 10%.
+
+</div>
+</div>
+</div>
+
+<div itemscope itemtype="http://schema.org/Question">
+
+<h3 itemprop="name">Is there anything else, other than my disability rating, that may affect the amount of compensation I receive?</h3>
+<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
+<div itemprop="text">
+
+Yes. We may increase or decrease your compensation amount in certain situations. <br>
+<a href="/disability/compensation-rates">Learn more about compensation rates</a>
+
+</div>
+</div>
+</div>
+
+<div itemscope itemtype="http://schema.org/Question">
+
+<h3 itemprop="name">What happens after I get my disability rating?</h3>
+<div itemprop="acceptedAnswer" itemscope itemtype="http://schema.org/Answer">
+<div itemprop="text">
+
+<a href="/disability/about-disability-ratings/after-you-get-a-rating/">Find out what to expect after you get your rating</a>
+
+</div>
+</div>
+</div>
+
+------
+<span id="combined"></a>
+<h2>How we determine combined VA disability ratings</h2>
+
+If you have more than one disability, we’ll use the combined ratings table below to calculate your combined disability rating. 
+
+To make this table easier to use online, we’ve separated it into smaller tables, based on the percentage of the most severe, or highest rated, disability (as shown in the left column of each table). 
+
+<strong>Note:</strong> If you have 2 disabilities, each rated at 10% disabling, your combined disability rating is 19%. 
+
+<h3>Combined ratings table</h3>
+
+<ul class="usa-accordion" aria-multiselectable="true">
+<li>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="19-29">19% to 29% disabling</button>
+<div id="19-29" class="usa-accordion-content">
+
+|    | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **19** | 27 | 35 | 43 | 51 | 60 | 68 | 76 | 84 | 92 |
+| **20** | 28 | 36 | 44 | 52 | 60 | 68 | 76 | 84 | 92 |
+| **21** | 29 | 37 | 45 | 53 | 61 | 68 | 76 | 84 | 92 |
+| **22** | 30 | 38 | 45 | 53 | 61 | 69 | 77 | 84 | 92 |
+| **23** | 31 | 38 | 46 | 54 | 62 | 69 | 77 | 85 | 92 |
+| **24** | 32 | 39 | 47 | 54 | 62 | 70 | 77 | 85 | 92 |
+| **25** | 33 | 40 | 48 | 55 | 63 | 70 | 78 | 85 | 93 |
+| **26** | 33 | 41 | 48 | 56 | 63 | 70 | 78 | 85 | 93 |
+| **27** | 34 | 42 | 49 | 56 | 64 | 71 | 78 | 85 | 93 |
+| **28** | 35 | 42 | 50 | 57 | 64 | 71 | 78 | 86 | 93 |
+| **29** | 36 | 43 | 50 | 57 | 65 | 72 | 79 | 86 | 93 |
+
+<strong>Tip:</strong> Look for your highest disability rating (or highest combined rating) in the left column, and your next lowest disability rating in the top column. Your combined rating is the number where the 2 intersect on the chart, rounded to the nearest 10%.
+</div>
+</li>
+<li>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="30-39">30% to 39% disabling</button>
+<div id="30-39" class="usa-accordion-content">
+
+|    | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **30** | 37 | 44 | 51 | 58 | 65 | 72 | 79 | 86 | 93 |
+| **31** | 38 | 45 | 52 | 59 | 66 | 72 | 79 | 86 | 93 |
+| **32** | 39 | 46 | 52 | 59 | 66 | 73 | 80 | 86 | 93 |
+| **33** | 40 | 46 | 53 | 60 | 67 | 73 | 80 | 87 | 93 |
+| **34** | 41 | 47 | 54 | 60 | 67 | 74 | 80 | 87 | 93 |
+| **35** | 42 | 48 | 55 | 61 | 68 | 74 | 81 | 87 | 94 |
+| **36** | 42 | 49 | 55 | 62 | 68 | 74 | 81 | 87 | 94 |
+| **37** | 43 | 50 | 56 | 62 | 69 | 75 | 81 | 87 | 94 |
+| **38** | 44 | 50 | 57 | 63 | 69 | 75 | 81 | 88 | 94 |
+| **39** | 45 | 51 | 57 | 63 | 70 | 76 | 82 | 88 | 94 |
+
+<strong>Tip:</strong> Look for your highest disability rating (or highest combined rating) in the left column, and your next lowest disability rating in the top column. Your combined rating is the number where the 2 intersect on the chart, rounded to the nearest 10%.
+</div>
+</li>
+<li>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="40-49">40% to 49% disabling</button>
+<div id="40-49" class="usa-accordion-content">
+
+|    | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **40** | 46 | 52 | 58 | 64 | 70 | 76 | 82 | 88 | 94 |
+| **41** | 47 | 53 | 59 | 65 | 71 | 76 | 82 | 88 | 94 |
+| **42** | 48 | 54 | 59 | 65 | 71 | 77 | 83 | 88 | 94 |
+| **43** | 49 | 54 | 60 | 66 | 72 | 77 | 83 | 89 | 94 |
+| **44** | 50 | 55 | 61 | 66 | 72 | 78 | 83 | 89 | 94 |
+| **45** | 51 | 56 | 62 | 67 | 73 | 78 | 84 | 89 | 95 |
+| **46** | 51 | 57 | 62 | 68 | 73 | 78 | 84 | 89 | 95 |
+| **47** | 52 | 58 | 63 | 68 | 74 | 79 | 84 | 89 | 95 |
+| **48** | 53 | 58 | 64 | 69 | 74 | 79 | 84 | 90 | 95 |
+| **49** | 54 | 59 | 64 | 69 | 75 | 80 | 85 | 90 | 95 |
+
+<strong>Tip:</strong> Look for your highest disability rating (or highest combined rating) in the left column, and your next lowest disability rating in the top column. Your combined rating is the number where the 2 intersect on the chart, rounded to the nearest 10%.
+</div>
+</li>
+<li>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="50-59">50% to 59% disabling</button>
+<div id="50-59" class="usa-accordion-content">
+
+|    | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **50** | 55 | 60 | 65 | 70 | 75 | 80 | 85 | 90 | 95 |
+| **51** | 56 | 61 | 66 | 71 | 76 | 80 | 85 | 90 | 95 |
+| **52** | 57 | 62 | 66 | 71 | 76 | 81 | 86 | 90 | 95 |
+| **53** | 58 | 62 | 67 | 72 | 77 | 81 | 86 | 91 | 95 |
+| **54** | 59 | 63 | 68 | 72 | 77 | 82 | 86 | 91 | 95 |
+| **55** | 60 | 64 | 69 | 73 | 78 | 82 | 87 | 91 | 96 |
+| **56** | 60 | 65 | 69 | 74 | 78 | 82 | 87 | 91 | 96 |
+| **57** | 61 | 66 | 70 | 74 | 79 | 83 | 87 | 91 | 96 |
+| **58** | 62 | 66 | 71 | 75 | 79 | 83 | 87 | 92 | 96 |
+| **59** | 63 | 67 | 71 | 75 | 80 | 84 | 88 | 92 | 96 |
+
+<strong>Tip:</strong> Look for your highest disability rating (or highest combined rating) in the left column, and your next lowest disability rating in the top column. Your combined rating is the number where the 2 intersect on the chart, rounded to the nearest 10%.
+</div>
+</li>
+<li>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="60-69">60% to 69% disabling</button>
+<div id="60-69" class="usa-accordion-content">
+    
+|    | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **60** | 64 | 68 | 72 | 76 | 80 | 84 | 88 | 92 | 96 |
+| **61** | 65 | 69 | 73 | 77 | 81 | 84 | 88 | 92 | 96 |
+| **62** | 66 | 70 | 73 | 77 | 81 | 85 | 89 | 92 | 96 |
+| **63** | 67 | 70 | 74 | 78 | 82 | 85 | 89 | 93 | 96 |
+| **64** | 68 | 71 | 75 | 78 | 82 | 86 | 89 | 93 | 96 |
+| **65** | 69 | 72 | 76 | 79 | 83 | 86 | 90 | 93 | 97 |
+| **66** | 69 | 73 | 76 | 80 | 83 | 86 | 90 | 93 | 97 |
+| **67** | 70 | 74 | 77 | 80 | 84 | 87 | 90 | 93 | 97 |
+| **68** | 71 | 74 | 78 | 81 | 84 | 87 | 90 | 94 | 97 |
+| **69** | 72 | 75 | 78 | 81 | 85 | 88 | 91 | 94 | 97 |
+
+<strong>Tip:</strong> Look for your highest disability rating (or highest combined rating) in the left column, and your next lowest disability rating in the top column. Your combined rating is the number where the 2 intersect on the chart, rounded to the nearest 10%.
+</div>
+</li>
+<li>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="70-79">70% to 79% disabling</button>
+<div id="70-79" class="usa-accordion-content">
+
+|    | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **70** | 73 | 76 | 79 | 82 | 85 | 88 | 91 | 94 | 97 |
+| **71** | 74 | 77 | 80 | 83 | 86 | 88 | 91 | 94 | 97 |
+| **72** | 75 | 78 | 80 | 83 | 86 | 89 | 92 | 94 | 97 |
+| **73** | 76 | 78 | 81 | 84 | 87 | 89 | 92 | 95 | 97 |
+| **74** | 77 | 79 | 82 | 84 | 87 | 90 | 92 | 95 | 97 |
+| **75** | 78 | 80 | 83 | 85 | 88 | 90 | 93 | 95 | 98 |
+| **76** | 78 | 81 | 83 | 86 | 88 | 90 | 93 | 95 | 98 |
+| **77** | 79 | 82 | 84 | 86 | 89 | 91 | 93 | 95 | 98 |
+| **78** | 80 | 82 | 85 | 87 | 89 | 91 | 93 | 96 | 98 |
+| **79** | 81 | 83 | 85 | 87 | 90 | 92 | 94 | 96 | 98 |
+
+<strong>Tip:</strong> Look for your highest disability rating (or highest combined rating) in the left column, and your next lowest disability rating in the top column. Your combined rating is the number where the 2 intersect on the chart, rounded to the nearest 10%.
+</div>
+</li>
+<li>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="80-89">80% to 89% disabling</button>
+<div id="80-89" class="usa-accordion-content">
+
+|    | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **80** | 82 | 84 | 86 | 88 | 90 | 92 | 94 | 96 | 98 |
+| **81** | 83 | 85 | 87 | 89 | 91 | 92 | 94 | 96 | 98 |
+| **82** | 84 | 86 | 87 | 89 | 91 | 93 | 95 | 96 | 98 |
+| **83** | 85 | 86 | 88 | 90 | 92 | 93 | 95 | 97 | 98 |
+| **84** | 86 | 87 | 89 | 90 | 92 | 94 | 95 | 97 | 98 |
+| **85** | 87 | 88 | 90 | 91 | 93 | 94 | 96 | 97 | 99 |
+| **86** | 87 | 89 | 90 | 92 | 93 | 94 | 96 | 91 | 99 |
+| **87** | 88 | 90 | 91 | 92 | 94 | 95 | 96 | 97 | 99 |
+| **88** | 89 | 90 | 92 | 93 | 94 | 95 | 96 | 98 | 99 |
+| **89** | 90 | 91 | 92 | 93 | 95 | 96 | 97 | 98 | 99 |
+
+<strong>Tip:</strong> Look for your highest disability rating (or highest combined rating) in the left column, and your next lowest disability rating in the top column. Your combined rating is the number where the 2 intersect on the chart, rounded to the nearest 10%.
+</div>
+</li>
+<li>
+<button class="usa-button-unstyled usa-accordion-button" aria-controls="90-94">90% to 94% disabling</button>
+<div id="90-94" class="usa-accordion-content">
+
+|    | 10 | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **90** | 91 | 92 | 93 | 94 | 95 | 96 | 97 | 98 | 99 |
+| **91** | 92 | 93 | 94 | 95 | 96 | 96 | 97 | 98 | 99 |
+| **92** | 93 | 94 | 94 | 95 | 96 | 97 | 98 | 98 | 99 |
+| **93** | 94 | 94 | 95 | 96 | 97 | 97 | 98 | 99 | 99 |
+| **94** | 95 | 95 | 96 | 96 | 97 | 98 | 98 | 99 | 99 |
+
+<strong>Tip:</strong> Look for your highest disability rating (or highest combined rating) in the left column, and your next lowest disability rating in the top column. Your combined rating is the number where the 2 intersect on the chart, rounded to the nearest 10%.
+</div>
+</li>
+</ul>
+
+[Download the full combined ratings table (PDF)](https://www.benefits.va.gov/compensation/rates-index.asp)
+
+<h3>How we use the combined ratings table</h3>
+
+<strong>We’ll follow these steps to calculate your combined rating:</strong>
+  
+<h4>Step 1:</h4>
+We’ll start by putting your disability ratings in order, from highest to lowest percentage. <br>
+  <br>
+  <strong>For example:</strong> If you had 2 disabilities rated as 50% disabling and 30% disabling, we’d rank them in this order: 50%, then 30%.
+
+<h4>Step 2:</h4>
+Next, we’ll look for your highest rating in the left column of the combined ratings table, and the next highest rating in the top row of the combined ratings table. <br>
+  <br>
+  <strong>In our example:</strong> We’d look for 50 in the left column and 30 in the top row.
+  
+|    | 10 | 20 | *30* | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| ***50*** | 55 | 60 | 65 | 70 | 75 | 80 | 85 | 90 | 95 |
+
+<h4>Step 3:</h4>  
+Then, we’ll look across from the 50 in the left column and down from the 30 in the top row to find the number that appears where the left column and top row meet. This is the combined value of the 2 ratings. <br>
+  <br>
+  <strong>In our example:</strong> This would be 65.
+  
+|    | 10 | 20 | *30* | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| ***50*** | 55 | 60 | ***65*** | 70 | 75 | 80 | 85 | 90 | 95 |
+  
+<h4>Step 4:</h4>
+<strong>If you have 2 disabilities</strong><br>
+We’ll round that combined value to the nearest 10% to find your combined disability rating. We’ll round combined values ending in 1 to 4 down, and those ending in 5 to 9 up. <br>
+  <br>
+  <strong>In our example:</strong> Your combined disability rating would be 70%.
+  
+<h4>Step 5:</h4>
+<strong>If you have more than 2 disabilities</strong>
+We’ll repeat the process for each additional disability. This means we’ll take the combined value (before rounding) of the first 2 disability ratings and then combine that with the third highest rating, and so on until we’ve added all disability ratings. We’ll round the final value to the nearest 10% to find your combined disability rating. <br>
+  <br>
+  <strong>For example:</strong> If we added a third disability rated at 10% disabling to our original example, we would take your combined value of 65 and look for that number in the left column of the combined ratings table. We would then look for 10 in the top row—and find the number where the left column and top row meet. In this example, that number would be 69. <br>
+<br>  
+|    | *10* | 20 | 30 | 40 | 50 | 60 | 70 | 80 | 90 |
+| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
+| **60** | 64 | 68 | 72 | 76 | 80 | 84 | 88 | 92 | 96 |
+| **61** | 65 | 69 | 73 | 77 | 81 | 84 | 88 | 92 | 96 |
+| **62** | 66 | 70 | 73 | 77 | 81 | 85 | 89 | 92 | 96 |
+| **63** | 67 | 70 | 74 | 78 | 82 | 85 | 89 | 93 | 96 |
+| **64** | 68 | 71 | 75 | 78 | 82 | 86 | 89 | 93 | 96 |
+| ***65*** | ***69*** | 72 | 76 | 79 | 83 | 86 | 90 | 93 | 97 |
+
+<br>
+We would then round this number up to 70%, and this would be your combined disability rating.
+
+<h2>Get more information</h2>
+
+Watch our videos to learn more about how VA disability ratings and compensation work: <br>	
+[Compensation 101: How did I get this rating?](https://www.youtube.com/watch?v=oM7oYzL2DCg) <br>
+[Compensation 101: What is disability compensation?](https://www.youtube.com/watch?v=T3RodE0nGFc) <br>
+[Compensation 101: What is service connection?](https://www.youtube.com/watch?v=h4vKqUlrdys)
+
+If you need help understanding your benefits or accessing services, please call us at <a href="tel:+18778271000">877-827-1000</a>. We're here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. 


### PR DESCRIPTION
## Page to edit
url: https://vagov-content-pr-268.herokuapp.com/disability/about-disability-ratings/

## Origin of request (internal/stakeholder/user feedback)


## Description of what's needed (edits/link changes/additions)

Due to an anomaly in the CMS, we can't have these charts in a subway map. We need to change the subway map structure so it is just H4s listing steps in order to keep the charts. 

New branch: https://github.com/department-of-veterans-affairs/vagov-content/blob/content-disability-anomaly-fix/pages/disability/about-disability-ratings.md