### PR TITLE
Change "Apply for" to "File for" (disability)

### DIFF
--- a/pages/disability/about-disability-ratings/effective-date.md
+++ b/pages/disability/about-disability-ratings/effective-date.md
@@ -15,8 +15,8 @@ relatedlinks:
       title: Fully developed claim
       description: "File a fully developed claim and get a faster decision on your disability benefits claim."
     - url: /disability/how-to-file-claim/
-      title: How to apply for disability benefits
-      description: "Apply online now, or find out how to file a claim in person, by mail, or with the help of a trained professional."
+      title: How to file for disability benefits
+      description: "File online now, or find out how to file a claim in person, by mail, or with the help of a trained professional."
     - url: /disability/get-help-filing-claim/
       title: Get help filing your claim
       description: "Learn how an accredited representative with a Veterans Service Organization can help you file a disability claim."

--- a/pages/disability/eligibility/illnesses-within-one-year-of-discharge.md
+++ b/pages/disability/eligibility/illnesses-within-one-year-of-discharge.md
@@ -3,7 +3,7 @@ layout: page-breadcrumbs.html
 title: Disabilities That Appear Within 1 Year After Discharge
 heading: Disabilities that appear within 1 year after discharge
 display_title: Illnesses within 1 year after discharge
-description: Find out how to apply for VA disability compensation for a condition that started within one year after discharge from active military service. You may be able to get benefits for an illness like high blood pressure, arthritis, or diabetes if your symptoms appear within a year after discharge.
+description: Find out how to file for VA disability compensation for a condition that started within one year after discharge from active military service. You may be able to get benefits for an illness like high blood pressure, arthritis, or diabetes if your symptoms appear within a year after discharge.
 concurrence: incomplete
 plainlanguage: 11-2-16 certified in compliance with the Plain Writing Act
 template: detail-page
@@ -15,7 +15,7 @@ relatedlinks:
       title: Fully developed claim
       description: "File a fully developed claim and get a faster decision on your disability benefits claim."
     - url: /disability/how-to-file-claim/
-      title: How to apply for disability benefits
+      title: How to file for disability benefits
       description: "File a claim online now, or find out how to file a claim in person, by mail, or with the help of a trained professional."
     - url: /disability/get-help-filing-claim/
       title: Get help filing your claim

--- a/pages/disability/how-to-file-claim.md
+++ b/pages/disability/how-to-file-claim.md
@@ -3,8 +3,8 @@ layout: page-breadcrumbs.html
 title: How To File A VA Disability Claim
 heading: How to file a VA disability claim
 display_title: How to file a claim
-description: Find out how to file a VA disability claim for a service-connected disability online, by mail, in person, or with the help of a trained professional. Learn how to prepare to apply for VA disability, what documents you'll need, and how to get help filing your claim.
-keywords: how to file a va disability claim, apply for disability, filing a va disability claim, file a va disability claim 
+description: Find out how to file a VA disability claim for a service-connected disability online, by mail, in person, or with the help of a trained professional. Learn how to prepare to file for VA disability, what documents you'll need, and how to get help filing your claim.
+keywords: how to file a va disability claim, apply for disability, filing a va disability claim, file a va disability claim, file for disability
 order: 2
 plainlanguage: 11-02-16 certified in compliance with the Plain Writing Act
 template: detail-page
@@ -36,7 +36,7 @@ relatedlinks:
 <div itemscope itemtype ="http://schema.org/HowTo">
 <div class="va-introtext" itemprop="description">
 
-Find out how to file a claim for disability compensation or increased disability compensation. 
+Find out how to file a claim for disability compensation or increased disability compensation.
 
 </div>
 

--- a/pages/dummy-placeholder.md
+++ b/pages/dummy-placeholder.md
@@ -39,7 +39,7 @@ private: true
     <div class="small-12 usa-width-one-half medium-6 columns">
       <ul class="plain">
         <li>
-          <a href="/disability/how-to-file-claim/">How do I apply for disability benefits?</a>
+          <a href="/disability/how-to-file-claim/">How do I file for disability benefits?</a>
         </li>
         <li>
           <a href="/education/how-to-apply/">How do I apply for education benefits?</a>


### PR DESCRIPTION
## Page to edit
urls:
* Page title: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/introduction
* Related links "How to apply for disability benefits" https://staging.va.gov/disability/about-disability-ratings/effective-date/#more-information-about-filing--931
* Page desription & related links "How to apply for disability benefits" https://staging.va.gov/disability/eligibility/illnesses-within-one-year-of-discharge/#more-information-about-filing--921
* Page description: https://staging.va.gov/disability/how-to-file-claim/
* Dummy placeholder (probably unnecessary) - https://github.com/department-of-veterans-affairs/vagov-content/blob/master/pages/dummy-placeholder.md

## Origin of request (internal/stakeholder/user feedback)

As per [discussion in Slack](https://dsva.slack.com/archives/C5AGLBNRK/p1568645264002200), although https://github.com/department-of-veterans-affairs/va.gov-team/issues/1712 was accomplished, the page title still shows the "Apply for disability..." text. It should read "File for disability..." per @peggygannon.

## Description of what's needed (edits/link changes/additions)

Change copy to read "File for..." instead of "Apply for..." in the context of the 526 disability application.