### PR TITLE
Add subhead to megaMenu Records tab

### DIFF
--- a/fragments/megamenu/index.yml
+++ b/fragments/megamenu/index.yml
@@ -251,8 +251,7 @@
         - text: Get Veteran ID cards
           href: https://www.va.gov/records/get-veteran-id-cards/
       columnTwo:
-        # No title property for this section -
-        # https://github.com/department-of-veterans-affairs/vets.gov-team/issues/17695
+        title: Manage your records
         links:
         - text: Request your military records (DD214)
           href: https://www.va.gov/records/get-military-service-records/


### PR DESCRIPTION
## Page to edit
url: Any page, since the edit is in the header megamenu.

## Origin of request (internal/stakeholder/user feedback)
CMS team / internal

## Description of what's needed (edits/link changes/additions)
Background: _For quality control, while the Drupal CMS-generated menu is being QA'd and released, the Drupal-generated menu and this menu must match in order for the Drupal menu to be built and published._

Currently, the Records tab of the menu has a 3rd column that, unlike other hub tabs, does not have a header. 

However, Drupal cannot generate a blank menu item. The Drupal menu data structure will not match the current structure.

So, our solution is to re-add the subhead "Manage your records" to both the Drupal menu and the megamenu fragment here. 

<img width="1074" alt="new_records_header" src="https://user-images.githubusercontent.com/1181665/65343546-3a8d4600-dba3-11e9-88c2-2abe1d35fb7f.png">


Cc @jefflbrauer @andrewlewandowski @mnorthuis 
