### PR TITLE
19988: AC 2, 4, and 5 for 19988

### DIFF
--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -125,13 +125,13 @@ relatedlinks:
     <li><a href="#training-and-guides">Training and guides</a></li>
     <li><a href="#upcoming-events">Upcoming events</a></li>
     <li><a href="#policies-and-procedures">Policies and procedures</a></li>
-    <li><a href="#resources-to-support-students">Resources to support students</a></li>
+    <li><a href="#other-resources-to-support-you">Resources to support students</a></li>
   </ul>
 </div>
 
 ### Key resources for SCOs
 
-<a class="vads-u-text-decoration--none" href="https://www.benefits.va.gov/GIBILL/docs/job_aids//SCO_Handbook.pdf"><b>SCO Handbook</b></a>&nbsp; &nbsp; | &nbsp; &nbsp;<a class="vads-u-text-decoration--none" href="https://vaonce.vba.va.gov/vaonce_student/default.asp"><b>VA-ONCE</b></a>&nbsp; &nbsp; | &nbsp; &nbsp;<a class="vads-u-text-decoration--none" href="https://www.benefits.va.gov/GIBILL/docs/vaonce/VAONCEguide.pdf"><b>VA-ONCE Quick Reference Guide</b></a>&nbsp; &nbsp; | &nbsp; &nbsp;<a class="vads-u-text-decoration--none" href="https://inquiry.vba.va.gov/weamspub/buildSearchInstitutionCriteria.do"><b>WEAMS</b></a>&nbsp; &nbsp; | &nbsp; &nbsp;<a class="vads-u-text-decoration--none" href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/elr.asp"><b>Find your ELR</b></a>
+<a class="vads-u-text-decoration--none" href="https://www.benefits.va.gov/GIBILL/docs/job_aids//SCO_Handbook.pdf"><b>SCO Handbook</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://vaonce.vba.va.gov/vaonce_student/default.asp"><b>VA-ONCE</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://www.benefits.va.gov/GIBILL/docs/vaonce/VAONCEguide.pdf"><b>VA-ONCE Quick Reference Guide</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://inquiry.vba.va.gov/weamspub/buildSearchInstitutionCriteria.do"><b>WEAMS</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/elr.asp"><b>Find your ELR</b></a>
 
 <div data-widget-type="sco-announcements"></div>
 
@@ -274,9 +274,9 @@ Use these resources to get training and boost your skills to help support milita
                           </p>
                         </li>
                         <li class="hub-page-link-list__item vads-u-margin-top--0 vads-u-padding-bottom--1">
-                            <a href="https://www.benefits.va.gov/gibill/docs/vaonce/VA-ONCE_P042_Training.ppt" class="no-external-icon">
+                            <a href="https://www.benefits.va.gov/gibill/docs/vaonce/VAONCE_Training.pdf" class="no-external-icon">
                             <span class="hub-page-link-list__header">
-                                VA-ONCE P042—Training on enhancements in newest version
+                                Training on VA-ONCE newest enhancements, version P059
                                 <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
                             </span>
                           </a>


### PR DESCRIPTION
## Page to edit
url: staging.va.gov/school-administrators/

## Origin of request (internal/stakeholder/user feedback)
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19988

## Description of what's needed (edits/link changes/additions)
- [x] The "Resources to support students" jump link takes the user to the "Other resources to support your students" section at the bottom of the page when clicked
- [x] In the "VA-Once Information" sub-section of the "Training and Guides" section the "VA-ONCE P042—Training on enhancements in newest version" link:
a. Text is replaced with: "Training on VA-ONCE newest enhancements, version P059"
b. URL is replaced with: https://www.benefits.va.gov/gibill/docs/vaonce/VAONCE_Training.pdf
- [x] The "Key resources for SCOs" jump links fit on a single row (ex. 2 whitespace before and after pipe)

