### PR TITLE
[#93] Adds id for webchat div

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -20,4 +20,4 @@ vagovprod: false
   The "widget-type" should be registered at
   https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/static-pages/widgetTypes.js>
 -->
-<div data-widget-type="va-coronavirus-chatbot"></div>
+<div id="webchat" data-widget-type="va-coronavirus-chatbot"></div>


### PR DESCRIPTION
Co-authored-by Shefali Nayak <shefali.nayak@thoughtworks.com>

## Page to edit
url: https://dev.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)


## Description of what's needed (edits/link changes/additions)
We think the bot framework is using "webchat" as the id for conversation messages.
