### PR TITLE
[#93] Binds cdn version to 4.8.0 instead of latest

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -10,7 +10,7 @@ title: VA coronavirus chatbot
 # This line indicates that this page is not to be built to production (www.va.gov)
 vagovprod: false
 ---
-<script src="https://cdn.botframework.com/botframework-webchat/latest/webchat.js"></script>
+<script src="https://cdn.botframework.com/botframework-webchat/4.8.0/webchat.js"></script>
 <style>
 #webchat button {
     justify-content: left !important;


### PR DESCRIPTION
## Page to edit
url: https://dev.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)
Related to this [merged PR](https://github.com/department-of-veterans-affairs/vagov-content/pull/657)

## Description of what's needed (edits/link changes/additions)
Lock in cdn version instead of using latest

Note: We want to lock to a particular version, in order to have a stable base for testing. If we pull the latest from the CDN, it's possible that a given user will get a new version of the chatbot framework before we've had a chance to test it.