### PR TITLE
Uses gzipped es5 version (for IE11 compatibility) of latest release cdn for chatbot

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -10,7 +10,7 @@ title: VA coronavirus chatbot
 # This line indicates that this page is not to be built to production (www.va.gov)
 vagovprod: false
 ---
-<script src="https://cdn.botframework.com/botframework-webchat/4.8.0/webchat.js"></script>
+<script src="https://cdn.botframework.com/botframework-webchat/4.8.0/webchat-es5.js"></script>
 <style>
 #webchat button {
     justify-content: left !important;

--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -10,7 +10,7 @@ title: VA coronavirus chatbot
 # This line indicates that this page is not to be built to production (www.va.gov)
 vagovprod: false
 ---
-<script src="https://cdn.botframework.com/botframework-webchat/4.8.0/webchat-es5.js"></script>
+<script src="https://cdn.botframework.com/botframework-webchat/latest/webchat-es5.gzip.js"></script>
 <style>
 #webchat button {
     justify-content: left !important;


### PR DESCRIPTION
## Page to edit
url: https://dev.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)
Related to previous [issue](https://github.com/department-of-veterans-affairs/vagov-content/pull/658) and [department-of-veterans-affairs/covid19-chatbot#93] 

## Description of what's needed (edits/link changes/additions)
Per this [Slack thread](https://dsva.slack.com/archives/C011BG82ZL6/p1587501919461900), we want to use the gzipped webchat-es5 cdn link because webchat-es5 is IE11 compatible and the compressed version (gzip) brings it down to 700Kb (vs 3.1mb).
