### PR TITLE
Adjusts chatbot checkboxes to be aligned with top of label text

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -53,6 +53,7 @@ vagovprod: true
     opacity: 1.0;
     width: auto;
     height: 1.6rem;
+    margin-top: 5px !important;
 }
 
 /* labels for checkboxes */
@@ -66,6 +67,10 @@ vagovprod: true
 
 #webchat div.ac-input.ac-choiceSetInput-multiSelect {
     margin-bottom: 15px;
+}
+
+#webchat div.ac-input.ac-choiceSetInput-multiSelect > div {
+    align-items: flex-start !important;
 }
 
 .webchat__bubble__content {


### PR DESCRIPTION
## Page to edit
url: https://dev.va.gov/coronavirus-chatbot

## Origin of request (internal/stakeholder/user feedback)
Additional fix for [[department-of-veterans-affairs/covid19-chatbot#86](https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/86)] 

## Description of what's needed (edits/link changes/additions)
- Checkboxes are now aligned with the first line of the label text

**Before**
![IMG_6726D0DC1AD6-1](https://user-images.githubusercontent.com/60353062/80037425-8c8fa480-84c1-11ea-9f1a-0b4cf8ddbfc8.jpeg)


**After**
<img width="415" alt="Screen Shot 2020-04-22 at 5 46 55 PM" src="https://user-images.githubusercontent.com/60353062/80037442-944f4900-84c1-11ea-8e05-4f6f9c0f33c4.png">
