### PR TITLE
Adds last updated date to chatbot 

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -181,3 +181,6 @@ button.ac-pushButton.style-default:hover {
   https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/static-pages/widgetTypes.js>
 -->
 <div id="webchat" data-widget-type="va-coronavirus-chatbot"></div>
+<div class="last-updated usa-content">
+          Last updated: <time datetime="2020-04-28">April 28, 2020</time>
+</div>


### PR DESCRIPTION

## Page to edit
url: https://www.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)
[department-of-veterans-affairs/covid19-chatbot#126] 

## Description of what's needed (edits/link changes/additions)
- Current solution is manual
- This last updated date should match the date on the [VA.gov coronavirus FAQ page](https://www.va.gov/coronavirus-veteran-frequently-asked-questions/)

<img width="1089" alt="Screen Shot 2020-04-30 at 10 41 14 AM" src="https://user-images.githubusercontent.com/60353062/80724113-75f3d980-8acf-11ea-90f7-36be5a72a080.png">

