### PR TITLE
Updates date from VA coronavirus FAQ page

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -182,5 +182,5 @@ button.ac-pushButton.style-default:hover {
 -->
 <div id="webchat" data-widget-type="va-coronavirus-chatbot"></div>
 <div class="last-updated usa-content">
-          Last updated: <time datetime="2020-04-28">April 30, 2020</time>
+          Last updated: <time datetime="2020-04-30">April 30, 2020</time>
 </div>

--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -182,5 +182,5 @@ button.ac-pushButton.style-default:hover {
 -->
 <div id="webchat" data-widget-type="va-coronavirus-chatbot"></div>
 <div class="last-updated usa-content">
-          Last updated: <time datetime="2020-04-28">April 28, 2020</time>
+          Last updated: <time datetime="2020-04-28">April 30, 2020</time>
 </div>


### PR DESCRIPTION

## Page to edit
url: https://www.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)
[department-of-veterans-affairs/covid19-chatbot#126] 

## Description of what's needed (edits/link changes/additions)
Manually updates date again as it has changed on the FAQ page today
