### PR TITLE
 Fixes dropdown cutoff in larger font sizes iOS Safari

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -93,7 +93,7 @@ vagovprod: true
 
 /* side vertical container with avatar in it */
 .webchat__stackedLayout__avatar {
-    margin: 0 8px !important;
+    margin: 7px 8px 0 !important;
 }
 
 /* horizontal container with chat bubbles */

--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -77,6 +77,13 @@ vagovprod: true
     align-items: flex-start !important;
 }
 
+#webchat .ac-input.ac-multichoiceInput.ac-choiceSetInput-compact {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    padding-right: 2.5rem;
+}
+
 .webchat__bubble__content {
     border: 0 !important;
     border-radius: 5px !important;


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)
[department-of-veterans-affairs/covid19-chatbot#147]
[department-of-veterans-affairs/covid19-chatbot#83]

## Description of what's needed (edits/link changes/additions)
Dropdown text in large font sizes was being covered by the arrow icon. After some discussion with @artsymartha68 @toddstanich @1Copenut, here is our proposed solution:

<img width="499" alt="Screen Shot 2020-05-04 at 11 24 41 AM" src="https://user-images.githubusercontent.com/60353062/81005144-7a93f700-8e1b-11ea-849a-a9bedba75a25.png">

**Also in this PR, issue 83 was fixed so avatar icons and one-line chatbot responses are better aligned.**

<img width="513" alt="Screen Shot 2020-05-04 at 3 58 02 PM" src="https://user-images.githubusercontent.com/60353062/81007934-10ca1c00-8e20-11ea-8180-ca77e18ce85a.png">

