### PR TITLE
Fixes yellow focus halo for buttons

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -16,25 +16,42 @@ vagovprod: true
     margin-top: 20px;
 }
 
-#webchat button {
-    justify-content: left !important;
-    text-align: left !important;
-    overflow: visible !important;
-}
-
 #webchat button div {
     overflow: visible !important;
     white-space: pre-wrap !important;
     text-overflow: unset !important;
 }
 
+/* divs between buttons in button container */
+.ac-actionSet > div {
+    display: none;
+}
+
+/* button style in answers before being selected */
+button.ac-pushButton {
+    justify-content: left !important;
+    text-align: left !important;
+    overflow: visible !important;
+    margin: 4px !important;
+    font-weight: 700 !important;
+    /* $color-primary from design.va.gov */
+    color: #0071bb;
+    border: 2px solid #0071bb !important;
+}
+
+button.ac-pushButton:hover {
+    /* $color-primary-darker from design.va.gov */
+    color: #003e73;
+    border: 2px solid #003e73 !important;
+    background: white;
+}
+
 #webchat button:disabled {
-    margin: 0 !important;
     padding: 10px !important;
     min-height: 38px !important;
     background: #d6d7d9 !important;
     color: #ffffff !important;
-    border: 0;
+    border: 0 !important;
 }
 
 #webchat[watermark="true"] [role="complementary"] ul[role="list"]::after {
@@ -120,23 +137,6 @@ vagovprod: true
 /* padding around answer chat bubbles */
 div.ac-container.ac-adaptiveCard {
     padding: 16px 8px !important;
-}
-
-/* button style in answers before being selected */
-button.ac-pushButton.style-default {
-    margin: 0 !important;
-    /* $color-primary from design.va.gov */
-    color: #0071bb;
-    border: 2px solid #0071bb;
-    font-weight: 700 !important;
-}
-
-button.ac-pushButton.style-default:hover {
-    /* $color-primary-darker from design.va.gov */
-    color: #003e73;
-    border: 2px solid #003e73 !important;
-    background: white;
-    font-weight: 700 !important;
 }
 
 /* additional padding around answer chat bubbles


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)
[department-of-veterans-affairs/covid19-chatbot#98] 

## Description of what's needed (edits/link changes/additions)
- Yellow focus halo around answer buttons fixed for accessibility purposes
- Other button styles consolidated


**BEFORE**
![79390338-23de8000-7f35-11ea-8efd-c5c502fc0b59](https://user-images.githubusercontent.com/60353062/81602927-77f54c80-939b-11ea-8786-5d6894c85842.png)

**AFTER**
<img width="786" alt="Screen Shot 2020-05-11 at 3 11 00 PM" src="https://user-images.githubusercontent.com/60353062/81602890-657b1300-939b-11ea-8da5-a0023d461d01.png">
