### PR TITLE
[department-of-veterans-affairs/covid19-chatbot#98] fixes button cutoff

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -27,12 +27,17 @@ vagovprod: true
     display: none;
 }
 
+/* ancestor container of buttons */
+div.ac-container.ac-adaptiveCard > div > div {
+    overflow: unset !important;
+}
+
 /* button style in answers before being selected */
 button.ac-pushButton {
     justify-content: left !important;
     text-align: left !important;
     overflow: visible !important;
-    margin: 4px !important;
+    margin: 4px 0 !important;
     font-weight: 700 !important;
     /* $color-primary from design.va.gov */
     color: #0071bb;


### PR DESCRIPTION
## Page to edit
url: https://va.gov/coronavirus-chatbot

## Origin of request (internal/stakeholder/user feedback)
[department-of-veterans-affairs/covid19-chatbot#98]

## Description of what's needed (edits/link changes/additions)
Fixing button cutoff that broke in the previous focus halo fix.

**BEFORE**
![Screen Shot 2020-05-11 at 18 28 24](https://user-images.githubusercontent.com/19177102/81618489-73d62880-93b5-11ea-8a73-fdadc9505519.png)

**AFTER**
![Screen Shot 2020-05-11 at 18 27 53](https://user-images.githubusercontent.com/19177102/81618509-7df82700-93b5-11ea-8ce2-2430404bfa1e.png)


