### PR TITLE
Adds note about timeout above chatbot

### DIFF
--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -15,6 +15,7 @@ vagovprod: true
   Get answers to your questions about the coronavirus and VA benefits and services below.
 </div>
 
+**Note:** If you don't respond to the chatbot at least once every 60 minutes, you'll need to restart it to ask more questions.
 
 <!--
   The "widget-type" should be registered at
@@ -22,5 +23,5 @@ vagovprod: true
 -->
 <div id="webchat" data-widget-type="va-coronavirus-chatbot"></div>
 <div class="last-updated usa-content">
-          Last updated: <time datetime="2020-06-12">June 12, 2020</time>
+  Last updated: <time datetime="2020-06-12">June 12, 2020</time>
 </div>

--- a/pages/coronavirus-chatbot.md
+++ b/pages/coronavirus-chatbot.md
@@ -11,7 +11,7 @@ botframework_cdn: https://cdn.botframework.com/botframework-webchat/4.9.1/webcha
 # This line indicates that this page is not to be built to production (www.va.gov)
 vagovprod: true
 ---
-<div class="va-introtext">
+<div class="va-introtext vads-u-margin-bottom--2">
   Get answers to your questions about the coronavirus and VA benefits and services below.
 </div>
 


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)
[department-of-veterans-affairs/covid19-chatbot#112]

## Description of what's needed (edits/link changes/additions)
Message about timeout added as a note below the larger info text.

![Screen Shot 2020-06-18 at 11 47 14](https://user-images.githubusercontent.com/19177102/85042961-d7443a80-b159-11ea-9f39-a24899846f8c.png)

