### PR TITLE
Add Cerner test pages

### DIFF
--- a/pages/cerner-staging/appointments.md
+++ b/pages/cerner-staging/appointments.md
@@ -1,0 +1,14 @@
+---
+# Page setup.
+layout: page-breadcrumbs.html
+template: detail-page
+hidesidenav: true
+
+# The title of the tab.
+title: Cerner test environment - Appointments
+
+# This line indicates that this page is not to be built to production (www.va.gov)
+vagovprod: false
+---
+
+<div data-widget-type="schedule-view-va-appointments-page"></div>

--- a/pages/cerner-staging/messaging.md
+++ b/pages/cerner-staging/messaging.md
@@ -1,0 +1,14 @@
+---
+# Page setup.
+layout: page-breadcrumbs.html
+template: detail-page
+hidesidenav: true
+
+# The title of the tab.
+title: Cerner test environment - Messaging
+
+# This line indicates that this page is not to be built to production (www.va.gov)
+vagovprod: false
+---
+
+<div data-widget-type="secure-messaging-page"></div>

--- a/pages/cerner-staging/prescriptions.md
+++ b/pages/cerner-staging/prescriptions.md
@@ -1,0 +1,14 @@
+---
+# Page setup.
+layout: page-breadcrumbs.html
+template: detail-page
+hidesidenav: true
+
+# The title of the tab.
+title: Cerner test environment - Prescriptions
+
+# This line indicates that this page is not to be built to production (www.va.gov)
+vagovprod: false
+---
+
+<div data-widget-type="refill-track-prescriptions-page"></div>

--- a/pages/cerner-staging/records.md
+++ b/pages/cerner-staging/records.md
@@ -1,0 +1,14 @@
+---
+# Page setup.
+layout: page-breadcrumbs.html
+template: detail-page
+hidesidenav: true
+
+# The title of the tab.
+title: Cerner test environment - Records
+
+# This line indicates that this page is not to be built to production (www.va.gov)
+vagovprod: false
+---
+
+<div data-widget-type="get-medical-records-page"></div>

--- a/pages/cerner-staging/results.md
+++ b/pages/cerner-staging/results.md
@@ -1,0 +1,14 @@
+---
+# Page setup.
+layout: page-breadcrumbs.html
+template: detail-page
+hidesidenav: true
+
+# The title of the tab.
+title: Cerner test environment - Results
+
+# This line indicates that this page is not to be built to production (www.va.gov)
+vagovprod: false
+---
+
+<div data-widget-type="view-test-and-lab-results-page"></div>


### PR DESCRIPTION
## Page to edit
Does not build to prod

- `/cerner-testing/appointments`
- `/cerner-testing/messaging`
- `/cerner-testing/prescriptions`
- `/cerner-testing/records`
- `/cerner-testing/results`

## Origin of request (internal/stakeholder/user feedback)


## Description of what's needed (edits/link changes/additions)
Test pages for Cerner
