### PR TITLE
Add placeholder file

### DIFF
--- a/pages/cerner-staging/index.md
+++ b/pages/cerner-staging/index.md
@@ -1,5 +1,7 @@
 ---
 title: Cerner staging
+layout: page-breadcrumbs.html
+template: detail-page
 vagovprod: false
 ---
-<!-- Placeholder -->
+This file is a placeholder.

--- a/pages/cerner-staging/index.md
+++ b/pages/cerner-staging/index.md
@@ -1,0 +1,5 @@
+---
+title: Cerner staging
+vagovprod: false
+---
+<!-- Placeholder -->


### PR DESCRIPTION
This adds a placeholder file to get rid of the broken link errors we are seeing about the breadcrumbs in the `/cerner-staging/` files.