### PR TITLE
Add placeholder page to stop broken links in staging

### DIFF
--- a/pages/vsa/index.md
+++ b/pages/vsa/index.md
@@ -1,0 +1,7 @@
+---
+title: VSA
+layout: page-breadcrumbs.html
+template: detail-page
+vagovprod: false
+---
+<!-- Placeholder file -->


### PR DESCRIPTION
## Page to edit
url: /vsa (staging only)

## Origin of request (internal/stakeholder/user feedback)
Slack

## Description of what's needed (edits/link changes/additions)
Adds a placeholder at `/vsa` so that the broken link checker doesn't keep flagging a broken link in the breadcrumbs of `/vsa/design.html`
