### PR TITLE
Update banner.yml

### DIFF
--- a/fragments/home/banner.yml
+++ b/fragments/home/banner.yml
@@ -19,7 +19,7 @@
 #
 
 visible: true
-type: info
+type: warning
 title: VA facility and status updates
 
 content: |


### PR DESCRIPTION
# Description

This PR changes the homepage banner from `info` to `warning`, as it should have been.