### PR TITLE
Adjust analytics opt out page events

### DIFF
--- a/pages/analytics-opt-out.md
+++ b/pages/analytics-opt-out.md
@@ -16,7 +16,7 @@ private: true
         <h4>Click the below button to opt out of the VA.gov Google Analytics collection.</h4>
         <p>This opt-out will endure for this device/browser combination as long as you do not remove/reset your cookies. If you use multiple browsers or devices, you will need to opt out once for each device/browser combination to fully exclude yourself.</p>
         <p>The intended use case of this opt-out is for VA.gov team members performing testing or validation in the production environment with their personal devices. Other uses are not recommended. The only way to re-enable VA.gov Google Analytics collection is to clear the browser cookies. Therefore, this is not recommended for use on any shared devices.</p>
-        <button class="usa-button-primary" onClick="recordEvent({ event: 'analytics-opt-out', 'internal-user': 'true' }); event.target.classList = ['usa-button-disabled']; event.target.innerText='Opted out'">Opt out</button>
+        <button class="usa-button-primary" onClick="recordEvent({ event: 'analytics-opt-out'); recordEvent({ event: 'analytics-opt-out', 'internal-user': 'true' }); event.target.classList = ['usa-button-disabled']; event.target.innerText='Opted out'">Opt out</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Page to edit
url: 
https://www.va.gov/analytics-opt-out.html

For:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/36585

## Origin of request (internal/stakeholder/user feedback)
Analytics & Insights team audit of Domo dashboards

## Description of what's needed (edits/link changes/additions)
We have a chicken-and-the-egg situation with the analytics opt out event being fired:

```js
recordEvent({ event: 'analytics-opt-out', 'internal-user': 'true' });
```

The internal user flag is set to true at the property level so this event itself is not making it to the All view (which is what is exported to BigQuery).  Because of this, we can not create a list of GA user IDs and retroactively remove data from internal users.  This is causing discrepancies with our Domo dashboards and GA.

I just doubled up the event (without the internal user param), but open to suggestions for a pre-event name.
