### PR TITLE
set fetch-depth property when building, to save disk space

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,18 +22,21 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: vagov-content
+          fetch-depth: 1
 
       - name: Checkout content-build
         uses: actions/checkout@v2
         with:
           repository: department-of-veterans-affairs/content-build
           path: content-build
+          fetch-depth: 1
 
       - name: Checkout vets-website
         uses: actions/checkout@v2
         with:
           repository: department-of-veterans-affairs/vets-website
           path: vets-website
+          fetch-depth: 1
 
       - name: Get Node version
         id: get-node-version


### PR DESCRIPTION
The [Github Action](https://github.com/department-of-veterans-affairs/vagov-content/blob/main/.github/workflows/continuous-integration.yml) checks out the `vagov-content`, `content-build`, and `vets-website` repos.  This is possibly why we are seeing the actions [failing](https://github.com/department-of-veterans-affairs/vagov-content/actions/runs/6933979330/job/18862242911) with a failure that there's no space left on the device.  

Setting the fetch-depth will retrieve only the most recent commits to those repositories, which should (hopefully) give us enough space to complete the build.

```
System.IO.IOException: No space left on device : '/home/runner/runners/2.311.0/_diag/Worker_20231115-185030-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.Strategies.BufferedFileStreamStrategy.FlushWrite()
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at GitHub.Runner.Common.HostTraceListener.TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, Int32 id, String message)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
System.IO.IOException: No space left on device : '/home/runner/runners/2.311.0/_diag/Worker_20231115-185030-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.Strategies.BufferedFileStreamStrategy.FlushWrite()
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at GitHub.Runner.Common.HostTraceListener.TraceEvent(TraceEventCache eventCache, String source, TraceEventType eventType, Int32 id, String message)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Common.Tracing.Error(Exception exception)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/runners/2.311.0/_diag/Worker_20231115-185030-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.Strategies.BufferedFileStreamStrategy.FlushWrite()
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at System.Diagnostics.TraceSource.Flush()
   at GitHub.Runner.Common.TraceManager.Dispose(Boolean disposing)
   at GitHub.Runner.Common.TraceManager.Dispose()
   at GitHub.Runner.Common.HostContext.Dispose(Boolean disposing)
   at GitHub.Runner.Common.HostContext.Dispose()
   at GitHub.Runner.Worker.Program.Main(String[] args)
```
