### PR TITLE
Add social media links to Resources for Schools

### DIFF
--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -6,7 +6,7 @@ display_title: School administrators
 heading:
 permalink:
 source: https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/sco_info.asp
-lastupdate: 2023-11-20
+lastupdate: 2023-12-18
 show_git_lastupdate:
 concurrence:
 plainlanguage:
@@ -76,6 +76,20 @@ social:
           title: "Call MyVA411 for help:"
         - url:
           title: "If you have hearing loss, call TTY: 711."
+      - subhead: Follow us
+        links:
+        - url: https://www.facebook.com/VeteransBenefits
+          title: "VBA on Facebook"
+          icon: fa-facebook
+        - url: https://www.instagram.com/vabenefits
+          title: "VBA on Instagram"
+          icon: fa-instagram
+        - url: https://www.youtube.com/@VAVetBenefits
+          title: "VBA on YouTube"
+          icon: fa-youtube
+        - url: https://twitter.com/VAVetBenefits
+          title: "VBA on X"
+          icon: fa-twitter
 majorlinks:
   - heading:
     links:


### PR DESCRIPTION
Closes [issue 227](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/227)

Note: the new logo for X is not available in this version of Font Awesome. We are advised there is a separate initiative to address this issue on all the hub pages, and to follow their lead. Additionally, this link to X may not make the final "cut" to the production website.

<img width="343" alt="Screenshot 2023-12-20 at 9 26 15 AM" src="https://github.com/department-of-veterans-affairs/vagov-content/assets/1807967/74377c00-762e-4dbe-9e12-7571f29d5b6e">
