### PR TITLE
226 - Update breadcrumb text

### DIFF
--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -2,7 +2,7 @@
 layout: page-breadcrumbs.html
 template: education-sco
 title: Resources for schools
-display_title: School administrators
+display_title: Resources for schools
 heading:
 permalink:
 source: https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/sco_info.asp


### PR DESCRIPTION
Closes [#226](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/226)

Updates the breadcrumb text from "School administrators" to "Resources for schools"

Screenshot:
<img width="681" alt="Screenshot 2024-01-22 at 10 34 25 AM" src="https://github.com/department-of-veterans-affairs/vagov-content/assets/1807967/46acc7a7-4d0d-44ee-b230-494741d0ed71">
