### PR TITLE
Newsletter link

### DIFF
--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -57,6 +57,12 @@ social:
           title: "Call MyVA411 for help:"
         - url:
           title: "If you have hearing loss, call TTY: 711."
+      - subhead: Get GovDelivery updates
+        links:
+          - url: https://public.govdelivery.com/accounts/USVAVBA/subscriber/new
+            title: "Subscribe to the GovDelivery mailing list"
+            external: false
+            icon: fa-envelope
       - subhead: Follow us
         links:
         - url: https://www.facebook.com/VeteransBenefits


### PR DESCRIPTION
Closes[ #210](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/210)

Adds a section to the accordion in the side bar for the newsletter.
Screenshot:

<img width="351" alt="Screenshot 2024-01-23 at 2 15 57 PM" src="https://github.com/department-of-veterans-affairs/vagov-content/assets/1807967/fe80eb62-b33e-4187-ab57-d91a6c5c2108">

Notes:

- The URL (https://public.govdelivery.com/accounts/USVAVBA/subscribers/qualify) given in the ticket renders an error message, so I modified that to this: https://public.govdelivery.com/accounts/USVAVBA/subscriber/new
- In the design the icon next to the link is vertically centered, even when the text flows to multiple lines. That's not how the design system works. I left comments on the ticket about this.
- In the data I've indicated that this link is not "external" which should cause the link to open in the same window/tab, but that feature appears to be broken. We'll follow up with a new issue to address this problem.
