### PR TITLE
Fix 404 page inline style

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -46,7 +46,7 @@ private: true
               <input
                 type="submit"
                 value="Search"
-                style="borderRadius: 0 3px 3px 0;"
+                style="border-radius: 0 3px 3px 0;"
                 class="vads-u-height--full vads-u-margin--0"
               />
             </div>


### PR DESCRIPTION
The 404 page was recently update to replace a depreceated Formation class with design system utility classes. There is an inline style thought that is not formatted correctly so this PR makes that update.

**Before**

![Screenshot 2024-01-25 at 9 01 46 AM](https://github.com/department-of-veterans-affairs/vagov-content/assets/872479/e0b77d2c-abe1-41cf-b836-a38295e503d7)


**After**

![Screenshot 2024-01-25 at 9 03 15 AM](https://github.com/department-of-veterans-affairs/vagov-content/assets/872479/05b61c89-a1f9-4188-9982-38be929cde79)


## Page to edit
url: the 404 page

## Origin of request (internal/stakeholder/user feedback)

- https://github.com/department-of-veterans-affairs/content-build/pull/1864

## Description of what's needed (edits/link changes/additions)

