### PR TITLE
Ns/331 link target

### DIFF
--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -24,7 +24,7 @@ social:
       - subhead:
         links:
           - url: https://ask.va.gov/
-            label: "<b>Ask a Question (AVA)</b>"
+            label: "Ask a Question (AVA)"
             external: true
           - url:
             title: "Ask a question about GI Bill benefits."
@@ -155,19 +155,17 @@ relatedlinks:
 
 Use these resources to get training and boost your skills to help support military-connected students.
 
-<ul class="usa-unstyled-list">
-    <li class="hub-page-link-list__item">
-        <a href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/online_sco_training.asp" class="no-external-icon" onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Training and guides'});">
-            <span class="hub-page-link-list__header">
-                Required training for SCOs
-            </span>
-            <img class="all-link-arrow" src="/img/arrow-right-blue.svg" alt="right-arrow">
-        </a>
-        <br>
-        Required if your school has 20 or more GI Bill students
-    </li>
+<ul class="usa-unstyled-list vads-u-padding-bottom--2">
+    <li>
+    <span><va-link
+      active
+      href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/online_sco_training.asp"
+      text="Required training for SCOs"
+      onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Training and guides'});"
+    /></span>
+    <p class="va-nav-linkslist-description">Required if your school has 20 or more GI Bill students.</p>
+  </li>
 </ul>
-<br>
     <div class="usa-accordion" data-multiselectable="false">
         <ul class="usa-unstyled-list">
             <li>
@@ -265,7 +263,7 @@ Use these resources to get training and boost your skills to help support milita
                           </a>
                         </li>
                    </ul>
-                    <p><b>Reporting:</b></p>
+                    <p>Reporting:</p>
                     <ul>
                         <li>
                             <a href="https://www.benefits.va.gov/GIBILL/docs/factsheets/post-911_school_responsibilities.pdf" onClick="recordEvent({ event: 'nav-accordion-embedded-link-click'});">
@@ -400,7 +398,7 @@ Use these resources to get training and boost your skills to help support milita
 
 Learn about policies and procedures that apply to GI Bill legislation and VA educational programs and benefits.
 
-<ul class="usa-unstyled-list">
+<ul class="usa-unstyled-list vads-u-margin-bottom--2">
     <li class="hub-page-link-list__item">
         <a href="https://www.benefits.va.gov/GIBILL/handouts_forms.asp" class="no-external-icon" onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Policies and procedures'});">
             <span class="hub-page-link-list__header">
@@ -410,7 +408,6 @@ Learn about policies and procedures that apply to GI Bill legislation and VA edu
         </a>
     </li>
 </ul>
-<br>
 <ul class="usa-accordion">
     <li>
         <button class="usa-accordion-button usa-accordion-button-dark rail-heading"
@@ -419,7 +416,7 @@ Learn about policies and procedures that apply to GI Bill legislation and VA edu
           GI Bill program approval process
         </button>
         <div id="pnp-1" class="usa-accordion-content">
-           <div>
+           <div class="vads-u-margin-bottom--2">
                <strong>How does a facility begin the process of GI Bill program approval?</strong>
                <p>
                   The approval process for GI Bill programs generally begins with the <a href="https://nasaa-vetseducation.com/nasaa-contacts/" onClick="recordEvent({ event: 'nav-accordion-embedded-link-click'});">State Approving Agency (SAA)</a> of jurisdiction. Contact your SAA to seek approval for education and training programs in your respective state. They’re the path to a program’s eligibility for payment of VA education benefits.
@@ -435,8 +432,7 @@ Learn about policies and procedures that apply to GI Bill legislation and VA edu
                   </li>
               </ul>
            </div>
-           <br>
-           <div>
+           <div class="vads-u-margin-bottom--2">
                <strong>When is VA responsible for approval of education and training programs?</strong>
                <p>
                   VA will approve schools in some circumstances and for some states that don’t have an SAA assigned. If you fall into one of these groups, VA will review your application.
@@ -457,8 +453,7 @@ Learn about policies and procedures that apply to GI Bill legislation and VA edu
                    </li>
                </ul>
            </div>
-           <br>
-           <div>
+           <div class="vads-u-margin-bottom--2">
                <strong>Applications for jurisdictions where VA is acting as SAA:</strong>
                <ul>
                  <li><a href="https://www.benefits.va.gov/GIBILL/docs/SAAForms/VA_Initial_School_Approval_Accredited_Program.pdf" onClick="recordEvent({ event: 'nav-accordion-embedded-link-click'});">New application for approval—accredited institutions</a></li>
@@ -467,8 +462,7 @@ Learn about policies and procedures that apply to GI Bill legislation and VA edu
                  <li><a href="https://www.benefits.va.gov/GIBILL/docs/SAAForms/VA_Continued_Renewal_Non_Accredited_Application.pdf" onClick="recordEvent({ event: 'nav-accordion-embedded-link-click'});">Renewal or program amendment application—non-accredited institutions</a></li>
                </ul>
            </div>
-           <br>
-           <div>
+           <div class="vads-u-margin-bottom--2">
                <strong>How do you receive approval for on-the-job training programs?</strong>
                <p>
                 See our <a href="https://www.benefits.va.gov/gibill/docs/factsheets/Approval_of_OJT.pdf" onClick="recordEvent({ event: 'nav-accordion-embedded-link-click'});">Approval of On-the-Job Training Programs fact sheet</a>, which addresses the following requirements: programs, wages, and facilities.  See information for <a href="https://benefits.va.gov/gibill/federalemployerOJTandApprenticeshipProgramApprovalInformation.asp" onClick="recordEvent({ event: 'nav-accordion-embedded-link-click'});">Federal Agency program approval</a>.
@@ -544,37 +538,37 @@ Learn about policies and procedures that apply to GI Bill legislation and VA edu
   <ul class="va-nav-linkslist-list">
     <li>
       <a href="https://www.va.gov/education/about-gi-bill-benefits/" class="vads-u-text-decoration--underline">
-        <b>About GI Bill Benefits</b>
+        About GI Bill Benefits
       </a>
       <p class="va-nav-linkslist-description">Learn how the GI Bill works and explore your options to pay for school or training.</p>
     </li>
     <li>
       <a href="https://www.va.gov/education/gi-bill-comparison-tool/" class="vads-u-text-decoration--underline">
-        <b>Choosing GI Bill approved schools</b>
+        Choosing GI Bill approved schools
       </a>
       <p class="va-nav-linkslist-description">Find GI Bill approved schools and compare benefits with the GI Bill Comparison Tool.</p>
     </li>
     <li>
       <a href="https://www.va.gov/education/choosing-a-school/"class="vads-u-text-decoration--underline">
-        <b>How to use your GI Bill benefits</b>
+        How to use your GI Bill benefits
       </a>
       <p class="va-nav-linkslist-description">Find out how to use your GI bill benefits to advance your education and training.</p>
     </li>
     <li>
       <a href="https://www.va.gov/education/other-va-education-benefits/"class="vads-u-text-decoration--underline">
-        <b>Other educational assistance programs</b>
+        Other educational assistance programs
       </a>
       <p class="va-nav-linkslist-description">Find out if you’re eligible for programs that provide added GI Bill benefits. If you’re not eligible for the Post-9/11 GI Bill, learn about other VA education benefit programs for Veterans and National Guard or Reserve members.</p>
     </li>
     <li>
       <a href="https://www.va.gov/education/benefit-rates/post-9-11-gi-bill-rates/"class="vads-u-text-decoration--underline">
-        <b>Post-9/11 GI Bill and other VA education benefits rates</b>
+        Post-9/11 GI Bill and other VA education benefits rates
       </a>
       <p class="va-nav-linkslist-description">Check rate tables for the Post-9/11 GI Bill and other Veterans education benefits programs.</p>
     </li>
     <li>
       <a href="https://benefits.va.gov/GIBILL/study-abroad.asp" class="vads-u-text-decoration--underline">
-        <b>Study Abroad</b>
+        Study Abroad
       </a>
       <p class="va-nav-linkslist-description">Explore Post-9/11 GI Bill study abroad, covering tuition, fees, stipends, and exclusions like third-party fees and airfare.</p>
     </li>

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -101,6 +101,7 @@ relatedlinks:
 
 <div class="vads-u-padding-bottom--2p5">
   <ul>
+    <li><a href="#handbooks" onClick="recordEvent({ event: 'nav-jumplink-click'});">Handbooks</a></li>
     <li><a href="#training-and-guides" onClick="recordEvent({ event: 'nav-jumplink-click'});">Training and guides</a></li>
     <li><a href="#policies-and-procedures" onClick="recordEvent({ event: 'nav-jumplink-click'});">Policies and procedures</a></li>
     <li><a href="#other-resources-to-support-you" onClick="recordEvent({ event: 'nav-jumplink-click'});">Resources to support students</a></li>
@@ -118,6 +119,30 @@ relatedlinks:
     text="Education File Upload Portal"
   />
 </va-featured-content>
+
+<section class="usa-grid">
+  <div class="va-h-ruled--stars"></div>
+</section>
+
+<h2 id="handbooks" tabindex="-1">Handbooks</h2>
+<ul class="va-nav-linkslist-list">
+  <li>
+    <span><va-link
+      active
+      href="https://www.knowva.ebenefits.va.gov/system/templates/selfservice/va_ssnew/help/customer/locale/en-US/portal/554400000001018/content/554400000149088/School-Certifying-Official-Handbook-On-line"
+      text="School Certifying Official Handbook"
+    /></span>
+    <p class="va-nav-linkslist-description">Access the School Certifying Official Handbook online for valuable information and guidance on effectively managing VA education benefits.</p>
+  </li>
+  <li>
+    <span><va-link
+      active
+      href="https://www.knowva.ebenefits.va.gov/system/templates/selfservice/va_ssnew/help/customer/locale/en-US/portal/554400000001018/content/554400000208001/Employers-Certification-Handbook-On-The-Job-Training-Apprenticeship-Programs"
+      text="Employer’s Certification Handbook On-The-Job Training & Apprenticeship Programs"
+    /></span>
+    <p class="va-nav-linkslist-description">Access the Employer’s Certification Handbook for OJT/APP Programs.</p>
+  </li>
+</ul>
 
 <div data-widget-type="sco-announcements"><a href="https://www.benefits.va.gov/gibill/yellow_ribbon/yellow_ribbon_info_schools.asp">Education Service Yellow Ribbon Program Open Season</a></div>
 

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -2,7 +2,7 @@
 layout: page-breadcrumbs.html
 template: education-sco
 title: Resources for schools
-display_title: School administrators
+display_title: Resources for schools
 heading:
 permalink:
 source: https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/sco_info.asp

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -93,7 +93,7 @@ relatedlinks:
 
 ### On this page
 
-<div class="vads-u-padding-bottom--0p5">
+<div class="vads-u-padding-bottom--2p5">
   <ul>
     <li><a href="#training-and-guides" onClick="recordEvent({ event: 'nav-jumplink-click'});">Training and guides</a></li>
     <li><a href="#policies-and-procedures" onClick="recordEvent({ event: 'nav-jumplink-click'});">Policies and procedures</a></li>
@@ -101,9 +101,17 @@ relatedlinks:
   </ul>
 </div>
 
-### Key resources for SCOs
-
-<a class="vads-u-text-decoration--none" href="https://www.knowva.ebenefits.va.gov/system/templates/selfservice/va_ssnew/help/customer/locale/en-US/portal/554400000001018/content/554400000149088/School-Certifying-Official-Handbook-On-line"><b>SCO Handbook</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://www.knowva.ebenefits.va.gov/system/templates/selfservice/va_ssnew/help/customer/locale/en-US/portal/554400000001018/content/554400000208001/Employers-Certification-Handbook-On-The-Job-Training-Apprenticeship-Programs" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>OJT/APP SCO Handbook</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://benefits.va.gov/gibill/enrollment-manager/enrollment-manager-sco-user-guide.pptx" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>Enrollment Manager User Guide</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://iam.education.va.gov/auth/realms/dgib/protocol/openid-connect/auth?response_type=code&scope=openid+profile+email&client_id=apigw&redirect_uri=https://iam.education.va.gov:443/_codexch&nonce=ahr_u4pFHEcUAlXSHbKYjL72lLYnklBxnY4IjR1faIY&state=0" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>VA Education Platform Portal</b></a>&nbsp; |&nbsp;<a class="vads-u-text-decoration--none" href="https://inquiry.vba.va.gov/weamspub/buildSearchInstitutionCriteria.do" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>Public WEAMS</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/elr.asp" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>Find your ELR</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://benefits.va.gov/gibill/vrrap_educational_institutions.asp" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>VRRAP For Schools</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://benefits.va.gov/gibill/foreign_program_approval_information_for_schools.asp" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>Foreign Program Approval Information</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://benefits.va.gov/gibill/85_15_faqs.asp" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>85/15 FAQs</b></a>&nbsp; | &nbsp;<a class="vads-u-text-decoration--none" href="https://www.benefits.va.gov/GIBILL/docs/job_aids/VRE_SCO_Handbook.pdf" onClick="recordEvent({ event: 'nav-pipe-delimited-list-click', 'pipe-delimited-list-header': 'Key resources for SCOs'});"><b>Veteran Readiness and Employment (VR&E) SCO Handbook</b></a>
+<va-featured-content uswds>
+  <h3 slot="headline">Upload documents to VA</h3>
+  <p>
+    The Education File Upload Portal is for certifying officials to upload documents supporting compliance actions, designating or removing certifying officials, and more. The full list of accepted documents is found in the upload portal.
+  </p>
+  <va-link
+    active
+    href="https://www.my.va.gov/EducationFileUploads/s/"
+    text="Education File Upload Portal"
+  />
+</va-featured-content>
 
 <div data-widget-type="sco-announcements"><a href="https://www.benefits.va.gov/gibill/yellow_ribbon/yellow_ribbon_info_schools.asp">Education Service Yellow Ribbon Program Open Season</a></div>
 

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -57,6 +57,12 @@ social:
           title: "Call MyVA411 for help:"
         - url:
           title: "If you have hearing loss, call TTY: 711."
+      - subhead: Get GovDelivery updates
+        links:
+          - url: https://public.govdelivery.com/accounts/USVAVBA/subscriber/new
+            title: "Subscribe to the GovDelivery mailing list"
+            external: false
+            icon: fa-envelope
       - subhead: Follow us
         links:
         - url: https://www.facebook.com/VeteransBenefits

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -17,25 +17,6 @@ promo:
   - image: /img/hub-illustrations/education-sco.png
     heading: School Certifying Official (SCO) Handbook
     url: "https://www.knowva.ebenefits.va.gov/system/templates/selfservice/va_ssnew/help/customer/locale/en-US/portal/554400000001018/content/554400000149088/School-Certifying-Official-Handbook-On-line"
-crosslinks:
-  - heading: Other resources to support your students
-    links:
-      - url: /education/how-to-apply/
-        title: <b>How to apply for education benefits</b>
-      - url: https://www.benefits.va.gov/gibill/non_va_resources.asp#financial_aid
-        title: <b>Scholarships and financial aid</b>
-      - url: https://www.benefits.va.gov/GIBILL/docs/adult_college_completion_toolkit.pdf
-        title: <b>Adult College Completion Toolkit</b>
-      - url: https://www.benefits.va.gov/vow/
-        title: <b>Employment assistance</b>
-      - url: https://www.va.gov/resources/onet-interest-profiler-career-assessment/
-        title: <b>O*NET Interest Profiler career assessment</b>
-      - url: /education/gi-bill-comparison-tool/
-        title: <b>GI Bill Comparison Tool</b>
-      - url: https://benefits.va.gov/gibill//docs/fgib/Sample_MHA_Rate_Letters.pdf
-        title: <b>Colmery Act update sample letters</b>
-      - url: https://benefits.va.gov/gibill/fgibsummaries.asp#MHARelief
-        title: <b>Assistance for students impacted by Colmery Act MHA changes</b>
 social:
   - heading: Ask questions
     subsections:
@@ -515,6 +496,49 @@ Learn about policies and procedures that apply to GI Bill legislation and VA edu
     </li>
 </ul>
 </div>
-<section class="usa-grid">
-    <div class="va-h-ruled--stars"></div>
+
+<section class="merger-majorlinks va-nav-linkslist va-nav-linkslist--related">
+  <section class="field_related_links">
+    <h2 class="va-nav-linkslist-heading" tabindex="-1">
+      Learn about Veteran education benefits
+    </h2>
+  <ul class="va-nav-linkslist-list">
+    <li>
+      <a href="https://www.va.gov/education/about-gi-bill-benefits/" class="vads-u-text-decoration--underline">
+        <b>About GI Bill Benefits</b>
+      </a>
+      <p class="va-nav-linkslist-description">Learn how the GI Bill works and explore your options to pay for school or training.</p>
+    </li>
+    <li>
+      <a href="https://www.va.gov/education/gi-bill-comparison-tool/" class="vads-u-text-decoration--underline">
+        <b>Choosing GI Bill approved schools</b>
+      </a>
+      <p class="va-nav-linkslist-description">Find GI Bill approved schools and compare benefits with the GI Bill Comparison Tool.</p>
+    </li>
+    <li>
+      <a href="https://www.va.gov/education/choosing-a-school/"class="vads-u-text-decoration--underline">
+        <b>How to use your GI Bill benefits</b>
+      </a>
+      <p class="va-nav-linkslist-description">Find out how to use your GI bill benefits to advance your education and training.</p>
+    </li>
+    <li>
+      <a href="https://www.va.gov/education/other-va-education-benefits/"class="vads-u-text-decoration--underline">
+        <b>Other educational assistance programs</b>
+      </a>
+      <p class="va-nav-linkslist-description">Find out if you’re eligible for programs that provide added GI Bill benefits. If you’re not eligible for the Post-9/11 GI Bill, learn about other VA education benefit programs for Veterans and National Guard or Reserve members.</p>
+    </li>
+    <li>
+      <a href="https://www.va.gov/education/benefit-rates/post-9-11-gi-bill-rates/"class="vads-u-text-decoration--underline">
+        <b>Post-9/11 GI Bill and other VA education benefits rates</b>
+      </a>
+      <p class="va-nav-linkslist-description">Check rate tables for the Post-9/11 GI Bill and other Veterans education benefits programs.</p>
+    </li>
+    <li>
+      <a href="https://benefits.va.gov/GIBILL/study-abroad.asp" class="vads-u-text-decoration--underline">
+        <b>Study Abroad</b>
+      </a>
+      <p class="va-nav-linkslist-description">Explore Post-9/11 GI Bill study abroad, covering tuition, fees, stipends, and exclusions like third-party fees and airfare.</p>
+    </li>
+  </ul>
+  </section>
 </section>

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -6,7 +6,7 @@ display_title: School administrators
 heading:
 permalink:
 source: https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/sco_info.asp
-lastupdate: 2023-11-20
+lastupdate: 2023-12-18
 show_git_lastupdate:
 concurrence:
 plainlanguage:
@@ -76,6 +76,20 @@ social:
           title: "Call MyVA411 for help:"
         - url:
           title: "If you have hearing loss, call TTY: 711."
+      - subhead: Follow us
+        links:
+        - url: https://www.facebook.com/VeteransBenefits
+          title: "VBA on Facebook"
+          icon: fa-facebook
+        - url: https://www.instagram.com/vabenefits
+          title: "VBA on Instagram"
+          icon: fa-instagram
+        - url: https://www.youtube.com/@VAVetBenefits
+          title: "VBA on YouTube"
+          icon: fa-youtube
+        - url: https://twitter.com/VAVetBenefits
+          title: "VBA on X"
+          icon: fa-twitter
 majorlinks:
   - heading:
     links:

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -6,7 +6,7 @@ display_title: School administrators
 heading:
 permalink:
 source: https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/sco_info.asp
-lastupdate: 2023-12-18
+lastupdate: 2023-12-22
 show_git_lastupdate:
 concurrence:
 plainlanguage:
@@ -106,7 +106,7 @@ relatedlinks:
 
 <div>
   <p class="va-introtext">
-    Resources for schools is a one-stop shop for School Certifying Officials (SCOs) and school administrators assisting students who are using their VA benefits to pursue education and training programs. Find trainings, resources, guides, and information on GI Bill programs to support military-connected students.
+    Trainings, resources, guides, and information on GI Bill® programs geared towards School Certifying Officials (SCOs) and school administrators.
   <p>
 </div>
 

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -25,7 +25,6 @@ social:
         links:
           - url: https://ask.va.gov/
             label: "Ask a Question (AVA)"
-            external: true
           - url:
             title: "Ask a question about GI Bill benefits."
   - heading: Connect with us
@@ -36,13 +35,11 @@ social:
         links:
           - url: mailto:edutraining.vbaco@va.gov
             label: Email National Training Team - Schools
-            external: true
             icon: fa-envelope
       - subhead: Get updates
         links:
           - url: https://public.govdelivery.com/accounts/USVAVBA/subscriber/new
             label: Veteran Benefits email or text updates
-            external: true
             icon: fa-envelope
       - subhead: Call us
         links:
@@ -61,7 +58,6 @@ social:
         links:
           - url: https://public.govdelivery.com/accounts/USVAVBA/subscriber/new
             title: "Subscribe to the GovDelivery mailing list"
-            external: false
             icon: fa-envelope
       - subhead: Follow us
         links:

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -115,7 +115,6 @@ relatedlinks:
 <div class="vads-u-padding-bottom--0p5">
   <ul>
     <li><a href="#training-and-guides" onClick="recordEvent({ event: 'nav-jumplink-click'});">Training and guides</a></li>
-    <li><a href="#upcoming-events" onClick="recordEvent({ event: 'nav-jumplink-click'});">Upcoming events</a></li>
     <li><a href="#policies-and-procedures" onClick="recordEvent({ event: 'nav-jumplink-click'});">Policies and procedures</a></li>
     <li><a href="#other-resources-to-support-you" onClick="recordEvent({ event: 'nav-jumplink-click'});">Resources to support students</a></li>
   </ul>
@@ -375,12 +374,6 @@ Use these resources to get training and boost your skills to help support milita
     <div class="va-h-ruled--stars"></div>
 </section>
 <div>
-
-<div data-widget-type="sco-events"></div>
-
-<section class="usa-grid">
-    <div class="va-h-ruled--stars"></div>
-</section>
 
 <div>
     <h2 id="policies-and-procedures" tabindex="-1">Policies and procedures</h2>


### PR DESCRIPTION
Along with this issue, closes [#331](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/331).

All links are intended to open in the same tab, so this change removes metadata specifying that some links should open in a new tab. Additionally, it's no longer necessary to explicate that a link should open in the same tab, as this bug fix makes that the default behavior.
