### PR TITLE
Resources for Schools - Open links in the same tab

### DIFF
--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -25,7 +25,6 @@ social:
         links:
           - url: https://ask.va.gov/
             label: "Ask a Question (AVA)"
-            external: true
           - url:
             title: "Ask a question about GI Bill benefits."
   - heading: Connect with us
@@ -36,13 +35,11 @@ social:
         links:
           - url: mailto:edutraining.vbaco@va.gov
             label: Email National Training Team - Schools
-            external: true
             icon: fa-envelope
       - subhead: Get updates
         links:
           - url: https://public.govdelivery.com/accounts/USVAVBA/subscriber/new
             label: Veteran Benefits email or text updates
-            external: true
             icon: fa-envelope
       - subhead: Call us
         links:
@@ -61,7 +58,6 @@ social:
         links:
           - url: https://public.govdelivery.com/accounts/USVAVBA/subscriber/new
             title: "Subscribe to the GovDelivery mailing list"
-            external: false
             icon: fa-envelope
       - subhead: Follow us
         links:


### PR DESCRIPTION
Closes [#367](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/367)

All links are intended to open in the same tab, so this change removes metadata specifying that some links should open in a new tab—lines like this: `external: true`.

Additionally, a [bug fix](https://github.com/department-of-veterans-affairs/content-build/pull/1903) means that it will no longer necessary to explicate that a link should open in the same tab, as that will be the default behavior. For that reason, an instance of `external: false` is also being removed. Whether or not that bug fix is merged, this PR should be safe to merge, as currently, the values of `external` have no bearing on the outcome; all links are errantly opening in a new tab.