### PR TITLE
Rrevise "Trainings and webinars" section

### DIFF
--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -98,7 +98,7 @@ relatedlinks:
 <div class="vads-u-padding-bottom--2p5">
   <ul>
     <li><a href="#handbooks" onClick="recordEvent({ event: 'nav-jumplink-click'});">Handbooks</a></li>
-    <li><a href="#trainings-and-webinars" onClick="recordEvent({ event: 'nav-jumplink-click'});">Trainings and Webinars</a></li>
+    <li><a href="#trainings-and-webinars" onClick="recordEvent({ event: 'nav-jumplink-click'});">Trainings and webinars</a></li>
     <li><a href="#program-approvals" onClick="recordEvent({ event: 'nav-jumplink-click'});">Program Approvals</a></li>
     <li><a href="#policies-and-procedures" onClick="recordEvent({ event: 'nav-jumplink-click'});">Policies and procedures</a></li>
     <li><a href="#other-resources" onClick="recordEvent({ event: 'nav-jumplink-click'});">Other resources for schools</a></li>
@@ -155,13 +155,13 @@ relatedlinks:
 </section>
 
 <div>
-  <h2 id="trainings-and-webinars" tabindex="-1">Trainings and Webinars</h2>
+  <h2 id="trainings-and-webinars" tabindex="-1">Trainings and webinars</h2>
   <ul class="va-nav-linkslist-list">
     <li>
       <span><va-link
         href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/online_sco_training.asp"
         text="Training Requirements"
-        onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Trainings and Webinars'});"
+        onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Trainings and webinars'});"
       /></span>
       <p class="va-nav-linkslist-description">Essential training for VA student enrollment certifications and compliance.</p>
     </li>
@@ -169,25 +169,25 @@ relatedlinks:
       <span><va-link
         href="https://vba-tpss.vbatraining.org/assess/trkSignIn?refid=XSCO"
         text="SCO Training Portal"
-        onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Trainings and Webinars'});"
+        onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Trainings and webinars'});"
       /></span>
       <p class="va-nav-linkslist-description">Access to the VA Training Portal for school officials.</p>
     </li>
     <li>
       <span><va-link
-        href="https://www.benefits.va.gov/GIBILL/resources/education_resources/school_certifying_officials/Covered_Institutions.asp"
-        text="Covered Institution Status"
-        onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Trainings and Webinars'});"
+        href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/presentations.asp"
+        text="Office Hours and Webinars"
+        onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Trainings and webinars'});"
       /></span>
-      <p class="va-nav-linkslist-description">Find out if your organization is a covered educational institution.</p>
+      <p class="va-nav-linkslist-description">Join our office hours and webinars for information on the GI Bill, related legislation, and processes.</p>
     </li>
     <li>
       <span><va-link
-        href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/presentations.asp"
-        text="Education Service Webinars and Training"
-        onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Trainings and Webinars'});"
+        href="https://public.govdelivery.com/accounts/USVAVBA/subscriber/new"
+        text="Sign up for for trainings, webinar, and office hour updates"
+        onClick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Trainings and webinars'});"
       /></span>
-      <p class="va-nav-linkslist-description">Join our Office Hours and webinars for information on the GI Bill, related legislation, and processes.</p>
+      <p class="va-nav-linkslist-description">Subscribe to the GovDelivery mailing list to receive updates and other routine communications from Education Service about trainings, office hours, and more.</p>
     </li>
   </ul>
 </div>

--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -6,7 +6,7 @@ display_title: Resources for schools
 heading:
 permalink:
 source: https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/sco_info.asp
-lastupdate: 2023-12-22
+lastupdate: 2024-01-25
 show_git_lastupdate:
 concurrence:
 plainlanguage:


### PR DESCRIPTION
Closes [#420](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/420)

Revises the "Trainings and webinars" section with the latest approved content.

**Screenshot:**
<img width="687" alt="Screenshot 2024-02-23 at 4 21 57 PM" src="https://github.com/department-of-veterans-affairs/vagov-content/assets/1807967/cf404ce8-639b-4bc4-85bb-ce90bc0ff8d5">
