### PR TITLE
74399 ARF - Recreate content with ARP as heading

### DIFF
--- a/pages/accredited-representative-portal/index.md
+++ b/pages/accredited-representative-portal/index.md
@@ -1,6 +1,6 @@
 ---
 # Page setup.
-layout: accredited_representative_portal.html
+layout: representative.html
 template: detail-page
 hidesidenav: true
 
@@ -36,7 +36,7 @@ includeBreadcrumbs: false
     <div class="vads-u-display--flex above-footer-elements-container">
       <div class="vads-u-flex--auto">
         <span class="vads-u-text-align--justify">
-          <p>Last updated: <time datetime="2022-02-24">Mar 14, 2024</time></p>
+          <p>Last updated: <time datetime="2024-03-20">Mar 20, 2024</time></p>
         </span>
       </div>
       <div class="vads-u-flex--1 vads-u-text-align--right">


### PR DESCRIPTION
This creates content with the correct folder names and header name to be used by content-build accredited_representative_portal.html. The folder name and header is Accredited Representative Portal.

## Related Issues
[Rename to representative / accredited-representative-portal#74399](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/74399)

## Related PRs
[Revert "72956 add accredited representative page (#903)" #915](https://github.com/department-of-veterans-affairs/vagov-content/pull/915)
[72956 add accredited representative page #903](https://github.com/department-of-veterans-affairs/vagov-content/pull/903)

