### PR TITLE
Update URL for 'Enrollment Manager FAQs'

### DIFF
--- a/pages/school-administrators.md
+++ b/pages/school-administrators.md
@@ -343,7 +343,7 @@ relatedlinks:
       </li>
       <li>
        <span><va-link
-          href="https://benefits.va.gov/gibill/enrollment-manager/enrollment-manager-frequently-asked-questions.asp"
+          href="https://vbatraining.adobeconnect.com/ptgxzsnw11w7/default/index.html"
           text="Enrollment Manager FAQs"
         /></span>
       </li>


### PR DESCRIPTION
## Page to edit
url: https://www.va.gov/school-administrators/

## Origin of request (internal/stakeholder/user feedback)
Kate Caruso via email 8/5/24

## Description of what's needed (edits/link changes/additions)
Update the link for _Enrollment Manager FAQs_ to redirect to the most recent information
url: https://vbatraining.adobeconnect.com/ptgxzsnw11w7/default/index.html
