### PR TITLE
404 Page: replace .feature with utility classes

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -21,7 +21,7 @@ private: true
       <div class="usa-content vads-u-text-align--center vads-u-margin-x--auto">
         <h3>Sorry — we can’t find that page</h3>
         <p>Try the search box or one of the common questions below.</p>
-        <div class="feature vads-u-display--flex vads-u-align-items--center">
+        <div class="vads-u-display--flex vads-u-align-items--center vads-u-background-color--primary-alt-lightest vads-u-padding--2 vads-u-margin-y--3 vads-u-margin-x--0">
           <form
             accept-charset="UTF-8"
             action="/search/"


### PR DESCRIPTION
## Page to edit
url: any 404 page redirect

## Origin of request (internal/stakeholder/user feedback)

The `.feature` Formation class is deprecated in favor of the va-summary-box web component component.

In the case of the 404 not found pages though, that class is just being used as the background for the search input. To replicate that treatment, this PR will just replace the .feature class with [utility classes](https://design.va.gov/foundation/utilities/).

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2338

## Description of what's needed (edits/link changes/additions)

I tested this update in staging in the browser by removing the .feature class and adding the utility classes from the inspection screen. There were no visual differences.

![Screenshot 2024-11-25 at 12 29 44 PM](https://github.com/user-attachments/assets/dfd14d40-b161-4bba-a8e5-11eb75712f5a)
