### PR TITLE
fix(github-actions): update cache action to v4

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -34,7 +34,7 @@ runs:
 
     - name: Cache dependencies
       id: cache-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ inputs.path }}
         key: ${{ steps.get-node-version.outputs.NODE_VERSION }}-${{ inputs.key }}


### PR DESCRIPTION
## Page to edit
url: none

## Origin of request (internal/stakeholder/user feedback)

- [related issue](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/2045)

## Description of what's needed (edits/link changes/additions)

Actions are [failing](https://github.com/department-of-veterans-affairs/vagov-content/actions/runs/14710053112/job/41279879250?pr=943). This was discovered while updating [maintenance.md](https://github.com/department-of-veterans-affairs/vagov-content/pull/943)
